### PR TITLE
feat: rename Sessions UI copy to Chats and auto-title new chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A local-first Electron + Svelte desktop client for OpenClaw sessions.
 - Syncs gateway sessions via `openclaw sessions --json`
 - Sends messages via `openclaw agent --json` with session-aware routing (`--session-id` for gateway and local continuity, plus per-chat `--agent` for local threads)
 - Shows search, session switching, status/heartbeat, and basic settings
+- Lets you copy the active chat ID from the Context panel for support/debug workflows
 - Surfaces active agent badges in both chat list and chat header
 - Starts with right context rail collapsed for chat-focused default layout
 - Surfaces CLI failures with clearer timeout/exit/stderr diagnostics

--- a/README.md
+++ b/README.md
@@ -66,4 +66,5 @@ Output:
 
 - Non-gateway/demo sessions are handled locally (no CLI send)
 - Settings currently include gateway URL and theme
-- If the OpenClaw CLI is missing, sync/send errors will explicitly state that
+- Context panel includes per-chat routing controls and a copy-chat-id action
+- If the OpenClaw CLI is missing (or not executable), sync/send errors will explicitly state that

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A local-first Electron + Svelte desktop client for OpenClaw sessions.
 - Syncs gateway sessions via `openclaw sessions --json`
 - Sends messages via `openclaw agent --json` with session-aware routing (`--session-id` for gateway and local continuity, plus per-chat `--agent` for local threads)
 - Shows search, session switching, status/heartbeat, and basic settings
+- Surfaces active agent badges in both chat list and chat header
+- Starts with right context rail collapsed for chat-focused default layout
 - Surfaces CLI failures with clearer timeout/exit/stderr diagnostics
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Output:
 
 - `⌘/Ctrl + K` — focus search
 - `⌘/Ctrl + F` — focus search
+- `⌘/Ctrl + ,` — open settings
+- `⌘/Ctrl + Shift + R` — sync chats
 - `⌘/Ctrl + Shift + [` — previous session
 - `⌘/Ctrl + Shift + ]` — next session
 - `Esc` — close settings or collapse right panel

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A local-first Electron + Svelte desktop client for OpenClaw sessions.
 
 - Loads/saves sessions and messages in a local SQLite cache
 - Syncs gateway sessions via `openclaw sessions --json`
-- Sends messages to gateway-backed sessions via `openclaw agent --session-id ... --json`
+- Sends messages via `openclaw agent --json` with session-aware routing (`--session-id` for gateway and local continuity, plus per-chat `--agent` for local threads)
 - Shows search, session switching, status/heartbeat, and basic settings
 - Surfaces CLI failures with clearer timeout/exit/stderr diagnostics
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Output:
 
 - `⌘/Ctrl + K` — focus search
 - `⌘/Ctrl + F` — focus search
+- `Enter` (while search results are open) — jump to top match
 - `⌘/Ctrl + ,` — open settings
 - `⌘/Ctrl + Shift + R` — sync chats
 - `⌘/Ctrl + Shift + L` — focus composer

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Output:
 - `⌘/Ctrl + F` — focus search
 - `⌘/Ctrl + ,` — open settings
 - `⌘/Ctrl + Shift + R` — sync chats
+- `⌘/Ctrl + Shift + L` — focus composer
 - `⌘/Ctrl + Shift + [` — previous session
 - `⌘/Ctrl + Shift + ]` — next session
 - `Esc` — close settings or collapse right panel

--- a/electron/agent-response.cjs
+++ b/electron/agent-response.cjs
@@ -8,8 +8,10 @@ function toText(value) {
         if (typeof item === 'string') return item;
         if (item && typeof item === 'object') {
           if (typeof item.text === 'string') return item.text;
+          if (typeof item.output_text === 'string') return item.output_text;
           if (typeof item.content === 'string') return item.content;
           if (typeof item.value === 'string') return item.value;
+          if (Array.isArray(item.content)) return toText(item.content);
         }
         return '';
       })
@@ -22,6 +24,7 @@ function toText(value) {
   if (value && typeof value === 'object') {
     if (typeof value.message === 'string') return value.message;
     if (typeof value.text === 'string') return value.text;
+    if (typeof value.output_text === 'string') return value.output_text;
     if (typeof value.content === 'string') return value.content;
     if (typeof value.value === 'string') return value.value;
     if (Array.isArray(value.content)) return toText(value.content);
@@ -37,8 +40,10 @@ function extractTextFromPayload(payload) {
     toText(payload?.result?.payloads) ||
     toText(payload?.payloads) ||
     toText(payload?.result?.message) ||
+    toText(payload?.result?.output_text) ||
     toText(payload?.message) ||
     toText(payload?.text) ||
+    toText(payload?.output_text) ||
     toText(payload?.output) ||
     toText(payload?.response) ||
     ''

--- a/electron/agent-response.test.cjs
+++ b/electron/agent-response.test.cjs
@@ -10,6 +10,7 @@ test('extracts nested reply.message payload', () => {
 test('falls back through supported top-level keys', () => {
   assert.equal(extractAgentText(JSON.stringify({ message: 'm' })), 'm');
   assert.equal(extractAgentText(JSON.stringify({ text: 't' })), 't');
+  assert.equal(extractAgentText(JSON.stringify({ output_text: 'ot' })), 'ot');
   assert.equal(extractAgentText(JSON.stringify({ output: 'o' })), 'o');
   assert.equal(extractAgentText(JSON.stringify({ response: 'r' })), 'r');
 });
@@ -43,6 +44,19 @@ test('extracts text from object and block payloads', () => {
       })
     ),
     'first line\nsecond line'
+  );
+  assert.equal(
+    extractAgentText(
+      JSON.stringify({
+        result: {
+          payloads: [
+            { type: 'output_text', output_text: 'first output block' },
+            { type: 'output_text', output_text: 'second output block' }
+          ]
+        }
+      })
+    ),
+    'first output block\nsecond output block'
   );
 });
 

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -61,8 +61,15 @@ function normalizeAgentsPayload(value) {
       .filter(Boolean);
   }
 
-  if (value && typeof value === 'object' && value.agents !== undefined) {
-    return normalizeAgentsPayload(unwrapJsonStrings(value.agents));
+  if (value && typeof value === 'object') {
+    const candidateKeys = ['agents', 'data', 'payload', 'result', 'items'];
+    for (const key of candidateKeys) {
+      if (value[key] === undefined) continue;
+      const nested = normalizeAgentsPayload(unwrapJsonStrings(value[key]));
+      if (nested.length) {
+        return nested;
+      }
+    }
   }
 
   return [];
@@ -108,7 +115,11 @@ function parseAgentsListOutput(stdout) {
     if (inlineArray) candidates.push(inlineArray);
   }
 
+  const seen = new Set();
   for (const candidate of candidates) {
+    const key = typeof candidate === 'string' ? candidate.trim() : JSON.stringify(candidate);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
     try {
       const parsed = unwrapJsonStrings(candidate);
       const normalized = normalizeAgentsPayload(parsed);

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -6,15 +6,18 @@ function stripAnsi(text) {
     .trim();
 }
 
-function extractInlineJsonArray(line) {
-  const start = line.indexOf('[');
-  if (start === -1) return null;
+function extractBalancedInlineJson(line, startIndex) {
+  if (startIndex < 0 || startIndex >= line.length) return null;
+
+  const opening = line[startIndex];
+  const closing = opening === '[' ? ']' : opening === '{' ? '}' : null;
+  if (!closing) return null;
 
   let depth = 0;
   let inString = false;
   let escaping = false;
 
-  for (let index = start; index < line.length; index += 1) {
+  for (let index = startIndex; index < line.length; index += 1) {
     const char = line[index];
 
     if (inString) {
@@ -33,13 +36,29 @@ function extractInlineJsonArray(line) {
       continue;
     }
 
-    if (char === '[') depth += 1;
-    if (char === ']') {
+    if (char === opening) depth += 1;
+    if (char === closing) {
       depth -= 1;
       if (depth === 0) {
-        return line.slice(start, index + 1);
+        return line.slice(startIndex, index + 1);
       }
     }
+  }
+
+  return null;
+}
+
+function extractInlineJson(line) {
+  const firstBrace = line.indexOf('{');
+  const firstBracket = line.indexOf('[');
+
+  const starts = [firstBrace, firstBracket]
+    .filter((index) => index !== -1)
+    .sort((a, b) => a - b);
+
+  for (const startIndex of starts) {
+    const candidate = extractBalancedInlineJson(line, startIndex);
+    if (candidate) return candidate;
   }
 
   return null;
@@ -135,8 +154,8 @@ function parseAgentsListOutput(stdout) {
     const dataPrefix = trimmed.match(/^data:\s*(.+)$/i);
     if (dataPrefix?.[1]) candidates.push(dataPrefix[1]);
 
-    const inlineArray = extractInlineJsonArray(trimmed);
-    if (inlineArray) candidates.push(inlineArray);
+    const inlineJson = extractInlineJson(trimmed);
+    if (inlineJson) candidates.push(inlineJson);
   }
 
   const seen = new Set();

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -47,7 +47,7 @@ function extractInlineJsonArray(line) {
 
 function normalizeAgentsPayload(value) {
   if (Array.isArray(value)) {
-    return value
+    const normalizedRows = value
       .map((item) => {
         if (typeof item === 'string') {
           const id = item.trim();
@@ -69,10 +69,20 @@ function normalizeAgentsPayload(value) {
           displayName: typeof displayNameCandidate === 'string' && displayNameCandidate.trim()
             ? displayNameCandidate.trim()
             : id,
-          model: typeof modelCandidate === 'string' ? modelCandidate : ''
+          model: typeof modelCandidate === 'string' ? modelCandidate.trim() : ''
         };
       })
       .filter(Boolean);
+
+    const deduped = [];
+    const seenIds = new Set();
+    for (const row of normalizedRows) {
+      if (seenIds.has(row.id)) continue;
+      seenIds.add(row.id);
+      deduped.push(row);
+    }
+
+    return deduped;
   }
 
   if (value && typeof value === 'object') {

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -49,13 +49,27 @@ function normalizeAgentsPayload(value) {
   if (Array.isArray(value)) {
     return value
       .map((item) => {
+        if (typeof item === 'string') {
+          const id = item.trim();
+          if (!id) return null;
+          return { id, displayName: id, model: '' };
+        }
+
         if (!item || typeof item !== 'object') return null;
-        const id = typeof item.id === 'string' ? item.id.trim() : '';
+
+        const idCandidate = item.id ?? item.agentId ?? item.agent_id ?? item.key;
+        const id = typeof idCandidate === 'string' ? idCandidate.trim() : '';
         if (!id) return null;
+
+        const displayNameCandidate = item.name ?? item.displayName ?? item.display_name ?? item.title;
+        const modelCandidate = item.model ?? item.modelId ?? item.model_id;
+
         return {
           id,
-          displayName: typeof item.name === 'string' && item.name.trim() ? item.name.trim() : id,
-          model: typeof item.model === 'string' ? item.model : ''
+          displayName: typeof displayNameCandidate === 'string' && displayNameCandidate.trim()
+            ? displayNameCandidate.trim()
+            : id,
+          model: typeof modelCandidate === 'string' ? modelCandidate : ''
         };
       })
       .filter(Boolean);

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -61,11 +61,35 @@ function normalizeAgentsPayload(value) {
       .filter(Boolean);
   }
 
-  if (value && typeof value === 'object' && Array.isArray(value.agents)) {
-    return normalizeAgentsPayload(value.agents);
+  if (value && typeof value === 'object' && value.agents !== undefined) {
+    return normalizeAgentsPayload(unwrapJsonStrings(value.agents));
   }
 
   return [];
+}
+
+function unwrapJsonStrings(value, depthLimit = 4) {
+  let current = value;
+  for (let depth = 0; depth < depthLimit; depth += 1) {
+    if (typeof current !== 'string') return current;
+    const trimmed = current.trim();
+    if (!trimmed) return current;
+
+    const looksJson =
+      trimmed.startsWith('{') ||
+      trimmed.startsWith('[') ||
+      (trimmed.startsWith('"') && trimmed.endsWith('"'));
+
+    if (!looksJson) return current;
+
+    try {
+      current = JSON.parse(trimmed);
+    } catch {
+      return current;
+    }
+  }
+
+  return current;
 }
 
 function parseAgentsListOutput(stdout) {
@@ -86,7 +110,7 @@ function parseAgentsListOutput(stdout) {
 
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(candidate);
+      const parsed = unwrapJsonStrings(candidate);
       const normalized = normalizeAgentsPayload(parsed);
       if (normalized.length > 0) return normalized;
     } catch {

--- a/electron/agents-list.cjs
+++ b/electron/agents-list.cjs
@@ -1,0 +1,103 @@
+function stripAnsi(text) {
+  return String(text || '')
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, '')
+    .replace(/^\uFEFF/, '')
+    .trim();
+}
+
+function extractInlineJsonArray(line) {
+  const start = line.indexOf('[');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = start; index < line.length; index += 1) {
+    const char = line[index];
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '[') depth += 1;
+    if (char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        return line.slice(start, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function normalizeAgentsPayload(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null;
+        const id = typeof item.id === 'string' ? item.id.trim() : '';
+        if (!id) return null;
+        return {
+          id,
+          displayName: typeof item.name === 'string' && item.name.trim() ? item.name.trim() : id,
+          model: typeof item.model === 'string' ? item.model : ''
+        };
+      })
+      .filter(Boolean);
+  }
+
+  if (value && typeof value === 'object' && Array.isArray(value.agents)) {
+    return normalizeAgentsPayload(value.agents);
+  }
+
+  return [];
+}
+
+function parseAgentsListOutput(stdout) {
+  const raw = stripAnsi(stdout);
+  if (!raw) return [];
+
+  const candidates = [raw];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const dataPrefix = trimmed.match(/^data:\s*(.+)$/i);
+    if (dataPrefix?.[1]) candidates.push(dataPrefix[1]);
+
+    const inlineArray = extractInlineJsonArray(trimmed);
+    if (inlineArray) candidates.push(inlineArray);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      const normalized = normalizeAgentsPayload(parsed);
+      if (normalized.length > 0) return normalized;
+    } catch {
+      // keep scanning
+    }
+  }
+
+  return [];
+}
+
+module.exports = {
+  parseAgentsListOutput,
+  normalizeAgentsPayload
+};

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -64,6 +64,19 @@ test('parseAgentsListOutput parses data: wrapped arrays from noisy output', () =
   ]);
 });
 
+test('parseAgentsListOutput extracts inline JSON objects from noisy log lines', () => {
+  const output = [
+    'info: warm-up complete',
+    'result: {"agents":[{"id":"main","name":"Primary"},{"id":"ops","name":"Ops"}]} trailing [debug]',
+  ].join('\n');
+
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [
+    { id: 'main', displayName: 'Primary', model: '' },
+    { id: 'ops', displayName: 'Ops', model: '' }
+  ]);
+});
+
 test('parseAgentsListOutput unwraps json-encoded string arrays', () => {
   const output = '"[{\\"id\\":\\"main\\",\\"name\\":\\"Primary\\"}]"';
   const result = parseAgentsListOutput(output);

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseAgentsListOutput, normalizeAgentsPayload } = require('./agents-list.cjs');
+
+test('normalizeAgentsPayload keeps valid ids and derives display names', () => {
+  const result = normalizeAgentsPayload([
+    { id: 'main', name: 'Primary', model: 'openai/gpt-5.3-codex' },
+    { id: 'ops', model: 'openai/gpt-5.1-codex' },
+    { id: '   ' },
+    null
+  ]);
+
+  assert.deepEqual(result, [
+    { id: 'main', displayName: 'Primary', model: 'openai/gpt-5.3-codex' },
+    { id: 'ops', displayName: 'ops', model: 'openai/gpt-5.1-codex' }
+  ]);
+});
+
+test('parseAgentsListOutput parses direct JSON arrays', () => {
+  const result = parseAgentsListOutput('[{"id":"main","name":"Primary"}]');
+  assert.deepEqual(result, [{ id: 'main', displayName: 'Primary', model: '' }]);
+});
+
+test('parseAgentsListOutput parses data: wrapped arrays from noisy output', () => {
+  const output = [
+    '[info] loading config',
+    'data: [{"id":"main"},{"id":"work","name":"Work Agent","model":"openai/gpt-5.1-codex"}]',
+    '[done]'
+  ].join('\n');
+
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [
+    { id: 'main', displayName: 'main', model: '' },
+    { id: 'work', displayName: 'Work Agent', model: 'openai/gpt-5.1-codex' }
+  ]);
+});

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -34,3 +34,15 @@ test('parseAgentsListOutput parses data: wrapped arrays from noisy output', () =
     { id: 'work', displayName: 'Work Agent', model: 'openai/gpt-5.1-codex' }
   ]);
 });
+
+test('parseAgentsListOutput unwraps json-encoded string arrays', () => {
+  const output = '"[{\\"id\\":\\"main\\",\\"name\\":\\"Primary\\"}]"';
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [{ id: 'main', displayName: 'Primary', model: '' }]);
+});
+
+test('parseAgentsListOutput unwraps nested data payload objects', () => {
+  const output = 'data: {"agents":"[{\\"id\\":\\"ops\\",\\"name\\":\\"Ops\\"}]"}';
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [{ id: 'ops', displayName: 'Ops', model: '' }]);
+});

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -16,6 +16,22 @@ test('normalizeAgentsPayload keeps valid ids and derives display names', () => {
   ]);
 });
 
+test('normalizeAgentsPayload accepts string entries and alternate id/display/model keys', () => {
+  const result = normalizeAgentsPayload([
+    'main',
+    { agentId: 'ops', displayName: 'Ops Agent', modelId: 'openai/gpt-5.1-codex' },
+    { agent_id: 'build', display_name: 'Build Bot', model_id: 'openai/gpt-5.3-codex' },
+    { key: 'triage', title: 'Triage', model: 'openai/gpt-5.1-codex' }
+  ]);
+
+  assert.deepEqual(result, [
+    { id: 'main', displayName: 'main', model: '' },
+    { id: 'ops', displayName: 'Ops Agent', model: 'openai/gpt-5.1-codex' },
+    { id: 'build', displayName: 'Build Bot', model: 'openai/gpt-5.3-codex' },
+    { id: 'triage', displayName: 'Triage', model: 'openai/gpt-5.1-codex' }
+  ]);
+});
+
 test('parseAgentsListOutput parses direct JSON arrays', () => {
   const result = parseAgentsListOutput('[{"id":"main","name":"Primary"}]');
   assert.deepEqual(result, [{ id: 'main', displayName: 'Primary', model: '' }]);

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -32,6 +32,19 @@ test('normalizeAgentsPayload accepts string entries and alternate id/display/mod
   ]);
 });
 
+test('normalizeAgentsPayload deduplicates duplicate ids and trims model values', () => {
+  const result = normalizeAgentsPayload([
+    { id: 'main', name: 'Primary', model: ' openai/gpt-5.3-codex ' },
+    { id: 'main', name: 'Duplicate should be ignored', model: 'ignored' },
+    { agentId: 'ops', displayName: 'Ops', modelId: ' openai/gpt-5.1-codex ' }
+  ]);
+
+  assert.deepEqual(result, [
+    { id: 'main', displayName: 'Primary', model: 'openai/gpt-5.3-codex' },
+    { id: 'ops', displayName: 'Ops', model: 'openai/gpt-5.1-codex' }
+  ]);
+});
+
 test('parseAgentsListOutput parses direct JSON arrays', () => {
   const result = parseAgentsListOutput('[{"id":"main","name":"Primary"}]');
   assert.deepEqual(result, [{ id: 'main', displayName: 'Primary', model: '' }]);

--- a/electron/agents-list.test.cjs
+++ b/electron/agents-list.test.cjs
@@ -46,3 +46,29 @@ test('parseAgentsListOutput unwraps nested data payload objects', () => {
   const result = parseAgentsListOutput(output);
   assert.deepEqual(result, [{ id: 'ops', displayName: 'Ops', model: '' }]);
 });
+
+test('parseAgentsListOutput handles deeply nested wrapper keys', () => {
+  const output = JSON.stringify({
+    data: {
+      result: {
+        items: [{ id: 'work', name: 'Work Agent', model: 'openai/gpt-5.1-codex' }]
+      }
+    }
+  });
+
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [{ id: 'work', displayName: 'Work Agent', model: 'openai/gpt-5.1-codex' }]);
+});
+
+test('parseAgentsListOutput handles json-string wrappers around payload containers', () => {
+  const output = JSON.stringify({
+    payload: JSON.stringify({
+      data: JSON.stringify({
+        agents: JSON.stringify([{ id: 'main', name: 'Primary' }])
+      })
+    })
+  });
+
+  const result = parseAgentsListOutput(output);
+  assert.deepEqual(result, [{ id: 'main', displayName: 'Primary', model: '' }]);
+});

--- a/electron/cli-error.cjs
+++ b/electron/cli-error.cjs
@@ -7,6 +7,10 @@ function summarizeExecError(error, fallback = 'unknown error') {
     return 'OpenClaw CLI not found on PATH.';
   }
 
+  if (error.code === 'EACCES' || error.code === 'EPERM') {
+    return 'OpenClaw CLI is not executable (permission denied).';
+  }
+
   if (error.killed || error.signal === 'SIGTERM') {
     messageParts.push('command timed out');
   }

--- a/electron/cli-error.test.cjs
+++ b/electron/cli-error.test.cjs
@@ -7,6 +7,18 @@ test('maps ENOENT to missing CLI message', () => {
   assert.equal(message, 'OpenClaw CLI not found on PATH.');
 });
 
+test('maps permission errors to executable guidance', () => {
+  assert.equal(
+    summarizeExecError({ code: 'EACCES' }, 'fallback'),
+    'OpenClaw CLI is not executable (permission denied).'
+  );
+
+  assert.equal(
+    summarizeExecError({ code: 'EPERM' }, 'fallback'),
+    'OpenClaw CLI is not executable (permission denied).'
+  );
+});
+
 test('prefers stderr details and includes timeout/exit context', () => {
   const message = summarizeExecError(
     {

--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -205,7 +205,7 @@ class ChatDatabase {
     const normalizedAgentId = typeof agentId === 'string' && agentId.trim() ? agentId.trim() : 'main';
     const normalizedDisplayName = typeof agentDisplayName === 'string' && agentDisplayName.trim()
       ? agentDisplayName.trim()
-      : normalizedAgentId;
+      : (normalizedAgentId === 'main' ? 'Primary' : normalizedAgentId);
 
     const result = this.db.prepare(`
       UPDATE sessions

--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -37,6 +37,8 @@ class ChatDatabase {
         unread INTEGER NOT NULL DEFAULT 0,
         chip TEXT NOT NULL,
         status TEXT NOT NULL,
+        agent_id TEXT NOT NULL DEFAULT 'main',
+        agent_display_name TEXT NOT NULL DEFAULT 'Primary',
         created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
         FOREIGN KEY(group_id) REFERENCES sections(id) ON DELETE CASCADE
       );
@@ -89,6 +91,22 @@ class ChatDatabase {
         WHERE rowid = new.id;
       END;
     `);
+
+    this.#ensureSessionAgentColumns();
+  }
+
+  #ensureSessionAgentColumns() {
+    const columns = this.db.prepare("PRAGMA table_info('sessions')").all();
+    const hasAgentId = columns.some((column) => column.name === 'agent_id');
+    const hasAgentDisplayName = columns.some((column) => column.name === 'agent_display_name');
+
+    if (!hasAgentId) {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'main'");
+    }
+
+    if (!hasAgentDisplayName) {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_display_name TEXT NOT NULL DEFAULT 'Primary'");
+    }
   }
 
   #seedIfNeeded() {
@@ -130,7 +148,16 @@ class ChatDatabase {
       .all();
     const sessions = this.db
       .prepare(`
-        SELECT id, group_id as groupId, name, channel, preview, unread, chip, status
+        SELECT id,
+               group_id as groupId,
+               name,
+               channel,
+               preview,
+               unread,
+               chip,
+               status,
+               COALESCE(NULLIF(trim(agent_id), ''), 'main') as agentId,
+               COALESCE(NULLIF(trim(agent_display_name), ''), 'Primary') as agentDisplayName
         FROM sessions
         ORDER BY created_at DESC
       `)
@@ -151,6 +178,47 @@ class ChatDatabase {
     const messages = selectedSessionId ? this.getMessagesForSession(selectedSessionId) : [];
 
     return { sections, selectedSessionId, messages };
+  }
+
+  getSessionRouting(sessionId) {
+    if (!sessionId) return null;
+
+    const row = this.db.prepare(`
+      SELECT id,
+             group_id as groupId,
+             COALESCE(NULLIF(trim(agent_id), ''), 'main') as agentId,
+             COALESCE(NULLIF(trim(agent_display_name), ''), 'Primary') as agentDisplayName
+      FROM sessions
+      WHERE id = ?
+    `).get(sessionId);
+
+    if (!row) return null;
+    return {
+      id: row.id,
+      groupId: row.groupId,
+      agentId: row.agentId,
+      agentDisplayName: row.agentDisplayName
+    };
+  }
+
+  setSessionAgent(sessionId, { agentId, agentDisplayName } = {}) {
+    const normalizedAgentId = typeof agentId === 'string' && agentId.trim() ? agentId.trim() : 'main';
+    const normalizedDisplayName = typeof agentDisplayName === 'string' && agentDisplayName.trim()
+      ? agentDisplayName.trim()
+      : normalizedAgentId;
+
+    const result = this.db.prepare(`
+      UPDATE sessions
+      SET agent_id = ?,
+          agent_display_name = ?
+      WHERE id = ?
+    `).run(normalizedAgentId, normalizedDisplayName, sessionId);
+
+    if (!result.changes) {
+      throw new Error('Session not found');
+    }
+
+    return this.getSessionRouting(sessionId);
   }
 
   upsertGatewaySessions(rawSessions = []) {

--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -232,13 +232,14 @@ class ChatDatabase {
       throw new Error('sessionId and content are required');
     }
 
-    const session = this.db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId);
+    const session = this.db.prepare('SELECT id, name FROM sessions WHERE id = ?').get(sessionId);
     if (!session) {
       throw new Error('Session not found');
     }
 
     const messageKey = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const timestamp = this.#formatDisplayTimestamp(new Date());
+    const generatedTitle = this.#generateChatTitle(trimmed);
 
     const result = this.db
       .prepare(`
@@ -250,10 +251,16 @@ class ChatDatabase {
     this.db
       .prepare(`
         UPDATE sessions
-        SET preview = ?, created_at = strftime('%s','now')
+        SET preview = ?,
+            created_at = strftime('%s','now'),
+            name = CASE
+              WHEN trim(COALESCE(name, '')) = '' OR lower(trim(name)) = 'new chat'
+                THEN ?
+              ELSE name
+            END
         WHERE id = ?
       `)
-      .run(trimmed.slice(0, 160), sessionId);
+      .run(trimmed.slice(0, 160), generatedTitle, sessionId);
 
     const row = this.db
       .prepare(`
@@ -439,6 +446,15 @@ class ChatDatabase {
       hour12: false,
       timeZone: 'Europe/London'
     }).format(date);
+  }
+
+  #generateChatTitle(input) {
+    const trimmed = typeof input === 'string' ? input.trim() : '';
+    if (!trimmed) {
+      return 'New chat';
+    }
+
+    return trimmed.slice(0, 72);
   }
 
   #buildFtsQuery(input) {

--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -202,6 +202,11 @@ class ChatDatabase {
   }
 
   setSessionAgent(sessionId, { agentId, agentDisplayName } = {}) {
+    const existing = this.getSessionRouting(sessionId);
+    if (!existing) {
+      throw new Error('Session not found');
+    }
+
     const normalizedAgentId = typeof agentId === 'string' && agentId.trim() ? agentId.trim() : 'main';
     const normalizedDisplayName = typeof agentDisplayName === 'string' && agentDisplayName.trim()
       ? agentDisplayName.trim()
@@ -214,8 +219,19 @@ class ChatDatabase {
       WHERE id = ?
     `).run(normalizedAgentId, normalizedDisplayName, sessionId);
 
-    if (!result.changes) {
-      throw new Error('Session not found');
+    if (result.changes && (
+      existing.agentId !== normalizedAgentId ||
+      existing.agentDisplayName !== normalizedDisplayName
+    )) {
+      this.db.prepare(`
+        INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp, meta_pill, meta_detail)
+        VALUES (?, ?, 'system', 'System', ?, ?, 'info', 'routing updated')
+      `).run(
+        sessionId,
+        `system-agent-switch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        `Switched to ${normalizedDisplayName}`,
+        this.#formatDisplayTimestamp(new Date())
+      );
     }
 
     return this.getSessionRouting(sessionId);

--- a/electron/database.test.cjs
+++ b/electron/database.test.cjs
@@ -178,3 +178,35 @@ test('setSessionAgent persists per-chat agent metadata and defaults display name
     cleanupDb(db, tmpRoot);
   }
 });
+
+test('setSessionAgent normalizes blank agent to main and keeps Primary display name', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
+      VALUES ('main-agent-chat', 'active', 'Main agent chat', 'Local', '', 0, 'dm', 'live')
+    `).run();
+
+    const updated = db.setSessionAgent('main-agent-chat', {
+      agentId: '   ',
+      agentDisplayName: ' '
+    });
+
+    assert.equal(updated.agentId, 'main');
+    assert.equal(updated.agentDisplayName, 'Primary');
+
+    const hydrated = db.getSectionsWithSessions()
+      .flatMap((section) => section.sessions)
+      .find((session) => session.id === 'main-agent-chat');
+
+    assert.equal(hydrated.agentId, 'main');
+    assert.equal(hydrated.agentDisplayName, 'Primary');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});

--- a/electron/database.test.cjs
+++ b/electron/database.test.cjs
@@ -174,6 +174,11 @@ test('setSessionAgent persists per-chat agent metadata and defaults display name
 
     assert.equal(hydrated.agentId, 'openai/gpt-5.3-codex');
     assert.equal(hydrated.agentDisplayName, 'openai/gpt-5.3-codex');
+
+    const systemNotes = db.getMessagesForSession('agent-chat')
+      .filter((message) => message.role === 'system');
+    assert.equal(systemNotes.length, 1);
+    assert.equal(systemNotes[0].content, 'Switched to openai/gpt-5.3-codex');
   } finally {
     cleanupDb(db, tmpRoot);
   }
@@ -206,6 +211,10 @@ test('setSessionAgent normalizes blank agent to main and keeps Primary display n
 
     assert.equal(hydrated.agentId, 'main');
     assert.equal(hydrated.agentDisplayName, 'Primary');
+
+    const systemNotes = db.getMessagesForSession('main-agent-chat')
+      .filter((message) => message.role === 'system');
+    assert.equal(systemNotes.length, 0);
   } finally {
     cleanupDb(db, tmpRoot);
   }

--- a/electron/database.test.cjs
+++ b/electron/database.test.cjs
@@ -101,3 +101,49 @@ test('searchMessages still returns matches for regular terms', (t) => {
     cleanupDb(db, tmpRoot);
   }
 });
+
+test('addMessage auto-titles untitled chats from first user message and truncates to 72 chars', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
+      VALUES ('untitled-chat', 'active', 'New chat', 'Local', '', 0, 'dm', 'live')
+    `).run();
+
+    const content = `   ${'A'.repeat(90)}   `;
+    db.addMessage({ sessionId: 'untitled-chat', content, role: 'user', author: 'Operator' });
+
+    const session = db.db.prepare('SELECT name FROM sessions WHERE id = ?').get('untitled-chat');
+    assert.equal(session.name, 'A'.repeat(72));
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});
+
+test('addMessage keeps existing chat title stable after initial generation', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
+      VALUES ('stable-title-chat', 'active', '', 'Local', '', 0, 'dm', 'live')
+    `).run();
+
+    db.addMessage({ sessionId: 'stable-title-chat', content: '   First user message title   ', role: 'user', author: 'Operator' });
+    db.addMessage({ sessionId: 'stable-title-chat', content: 'Second message should not retitle', role: 'user', author: 'Operator' });
+
+    const session = db.db.prepare('SELECT name FROM sessions WHERE id = ?').get('stable-title-chat');
+    assert.equal(session.name, 'First user message title');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});

--- a/electron/database.test.cjs
+++ b/electron/database.test.cjs
@@ -147,3 +147,34 @@ test('addMessage keeps existing chat title stable after initial generation', (t)
     cleanupDb(db, tmpRoot);
   }
 });
+
+test('setSessionAgent persists per-chat agent metadata and defaults display name', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
+      VALUES ('agent-chat', 'active', 'Agent chat', 'Local', '', 0, 'dm', 'live')
+    `).run();
+
+    const updated = db.setSessionAgent('agent-chat', {
+      agentId: 'openai/gpt-5.3-codex'
+    });
+
+    assert.equal(updated.agentId, 'openai/gpt-5.3-codex');
+    assert.equal(updated.agentDisplayName, 'openai/gpt-5.3-codex');
+
+    const hydrated = db.getSectionsWithSessions()
+      .flatMap((section) => section.sessions)
+      .find((session) => session.id === 'agent-chat');
+
+    assert.equal(hydrated.agentId, 'openai/gpt-5.3-codex');
+    assert.equal(hydrated.agentDisplayName, 'openai/gpt-5.3-codex');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -1,7 +1,9 @@
 function stripAnsi(text) {
   return String(text || '')
     .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '')
-    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, '');
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, '')
+    .replace(/^\uFEFF/, '')
+    .replace(/[\u200B-\u200D\u2060]/g, '');
 }
 
 function extractBalancedJson(text, startIndex) {

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -1,3 +1,9 @@
+function stripAnsi(text) {
+  return String(text || '')
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g, '');
+}
+
 function extractBalancedJson(text, startIndex) {
   if (startIndex < 0 || startIndex >= text.length) return null;
 
@@ -64,7 +70,7 @@ function extractInlineJson(line) {
 
 function collectJsonCandidates(raw) {
   const candidates = [];
-  const text = String(raw);
+  const text = stripAnsi(raw);
   const lines = text
     .split(/\r?\n/)
     .map((line) => line.trim());
@@ -180,7 +186,7 @@ function normalizeGatewaySessionsPayload(raw, seen = new Set()) {
 }
 
 function parseJsonCandidate(candidate) {
-  let parsed = JSON.parse(candidate);
+  let parsed = JSON.parse(stripAnsi(candidate).trim());
 
   for (let depth = 0; depth < 5; depth += 1) {
     if (typeof parsed !== 'string') break;
@@ -195,7 +201,7 @@ function parseJsonCandidate(candidate) {
 }
 
 function parseGatewaySessionsOutput(stdout) {
-  const raw = String(stdout || '').trim();
+  const raw = stripAnsi(stdout).trim();
   if (!raw) return [];
 
   try {

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -67,11 +67,11 @@ function collectJsonCandidates(raw) {
   const text = String(raw);
   const lines = text
     .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+    .map((line) => line.trim());
+  const nonEmptyLines = lines.filter(Boolean);
 
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index];
+  for (let index = nonEmptyLines.length - 1; index >= 0; index -= 1) {
+    const line = nonEmptyLines[index];
     candidates.push(line);
 
     const dataPrefix = line.match(/^data:\s*(.+)$/i);

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -110,7 +110,12 @@ function collectJsonCandidates(raw) {
     }
   }
 
-  return candidates;
+  const seen = new Set();
+  return candidates.filter((candidate) => {
+    if (!candidate || seen.has(candidate)) return false;
+    seen.add(candidate);
+    return true;
+  });
 }
 
 function normalizeGatewaySessionsPayload(raw, seen = new Set()) {

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -85,6 +85,23 @@ function collectJsonCandidates(raw) {
     }
   }
 
+  const combinedDataLines = [];
+  for (const line of lines) {
+    const dataPrefix = line.match(/^data:\s?(.*)$/i);
+    if (dataPrefix) {
+      combinedDataLines.push(dataPrefix[1]);
+      continue;
+    }
+
+    if (combinedDataLines.length > 0) {
+      candidates.push(combinedDataLines.join('\n').trim());
+      combinedDataLines.length = 0;
+    }
+  }
+  if (combinedDataLines.length > 0) {
+    candidates.push(combinedDataLines.join('\n').trim());
+  }
+
   const fencedBlocks = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
   for (let index = 0; index < fencedBlocks.length; index += 1) {
     const candidate = fencedBlocks[index]?.[1]?.trim();

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -1,20 +1,65 @@
+function extractBalancedJson(text, startIndex) {
+  if (startIndex < 0 || startIndex >= text.length) return null;
+
+  const opening = text[startIndex];
+  const closing = opening === '{' ? '}' : opening === '[' ? ']' : null;
+  if (!closing) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === opening) {
+      depth += 1;
+      continue;
+    }
+
+    if (char === closing) {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
 function extractInlineJson(line) {
   const firstBrace = line.indexOf('{');
   const firstBracket = line.indexOf('[');
 
-  const starts = [
-    { index: firstBrace, open: '{', close: '}' },
-    { index: firstBracket, open: '[', close: ']' },
-  ].filter((entry) => entry.index !== -1)
-    .sort((a, b) => a.index - b.index);
+  const starts = [firstBrace, firstBracket]
+    .filter((index) => index !== -1)
+    .sort((a, b) => a - b);
 
-  const start = starts[0];
-  if (!start) return null;
+  for (const startIndex of starts) {
+    const candidate = extractBalancedJson(line, startIndex);
+    if (candidate) {
+      return candidate;
+    }
+  }
 
-  const end = line.lastIndexOf(start.close);
-  if (end === -1 || end <= start.index) return null;
-
-  return line.slice(start.index, end + 1);
+  return null;
 }
 
 function collectJsonCandidates(raw) {

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -125,6 +125,19 @@ function normalizeGatewaySessionsPayload(raw, seen = new Set()) {
     return raw;
   }
 
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (/^[\[{\"]/.test(trimmed)) {
+      try {
+        return normalizeGatewaySessionsPayload(JSON.parse(trimmed), seen);
+      } catch {
+        return [];
+      }
+    }
+
+    return [];
+  }
+
   if (typeof raw !== 'object') {
     return [];
   }

--- a/electron/gateway-sessions.cjs
+++ b/electron/gateway-sessions.cjs
@@ -164,11 +164,11 @@ function normalizeGatewaySessionsPayload(raw, seen = new Set()) {
 function parseJsonCandidate(candidate) {
   let parsed = JSON.parse(candidate);
 
-  for (let depth = 0; depth < 2; depth += 1) {
+  for (let depth = 0; depth < 5; depth += 1) {
     if (typeof parsed !== 'string') break;
 
     const trimmed = parsed.trim();
-    if (!trimmed || !/^[\[{]/.test(trimmed)) break;
+    if (!trimmed || !/^[\[{\"]/.test(trimmed)) break;
 
     parsed = JSON.parse(trimmed);
   }

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -32,6 +32,17 @@ test('normalizeGatewaySessionsPayload handles nested payload/data/items wrappers
   assert.deepEqual(normalizeGatewaySessionsPayload({ payload: { data: { items: sessions } } }), sessions);
 });
 
+test('normalizeGatewaySessionsPayload handles json-string data wrappers', () => {
+  const sessions = [{ sessionId: 'e3' }];
+  assert.deepEqual(normalizeGatewaySessionsPayload({ data: JSON.stringify({ sessions }) }), sessions);
+});
+
+test('normalizeGatewaySessionsPayload handles deeply encoded nested wrappers', () => {
+  const sessions = [{ sessionId: 'e4' }];
+  const encoded = JSON.stringify(JSON.stringify({ sessions }));
+  assert.deepEqual(normalizeGatewaySessionsPayload({ result: encoded }), sessions);
+});
+
 test('normalizeGatewaySessionsPayload safely handles cyclic objects', () => {
   const payload = {};
   payload.self = payload;

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -144,6 +144,12 @@ test('parseGatewaySessionsOutput unwraps data: prefixed json-encoded array paylo
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput unwraps deeply json-encoded payloads', () => {
+  const sessions = [{ sessionId: 'wrapped-deep' }];
+  const encoded = JSON.stringify(JSON.stringify(JSON.stringify({ sessions })));
+  assert.deepEqual(parseGatewaySessionsOutput(encoded), sessions);
+});
+
 test('parseGatewaySessionsOutput returns empty array for invalid output', () => {
   assert.deepEqual(parseGatewaySessionsOutput('not json'), []);
 });

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -102,6 +102,21 @@ test('parseGatewaySessionsOutput joins multiline data: payload into valid JSON',
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput keeps multiline data events separated by blank lines', () => {
+  const older = [{ sessionId: 'i3c-old' }];
+  const latest = [{ sessionId: 'i3c-new' }];
+  const stdout = [
+    'event: message',
+    'data: {"sessions":',
+    `data: ${JSON.stringify(older)}}`,
+    '',
+    'event: message',
+    'data: {"sessions":',
+    `data: ${JSON.stringify(latest)}}`,
+  ].join('\n');
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), latest);
+});
+
 test('parseGatewaySessionsOutput prefers latest fenced json payload', () => {
   const older = [{ sessionId: 'old' }];
   const latest = [{ sessionId: 'new' }];

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -150,6 +150,13 @@ test('parseGatewaySessionsOutput unwraps deeply json-encoded payloads', () => {
   assert.deepEqual(parseGatewaySessionsOutput(encoded), sessions);
 });
 
+test('parseGatewaySessionsOutput unwraps deeply encoded data: payloads', () => {
+  const sessions = [{ sessionId: 'wrapped-deep-data' }];
+  const encoded = JSON.stringify(JSON.stringify(JSON.stringify({ sessions })));
+  const stdout = `data: ${encoded}`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
 test('parseGatewaySessionsOutput returns empty array for invalid output', () => {
   assert.deepEqual(parseGatewaySessionsOutput('not json'), []);
 });

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -74,6 +74,18 @@ test('parseGatewaySessionsOutput extracts inline JSON array from log output', ()
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput extracts balanced inline JSON when trailing text contains brackets', () => {
+  const sessions = [{ sessionId: 'i2b' }];
+  const stdout = `trace: payload=${JSON.stringify({ sessions })} trailing [debug] marker`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
+test('parseGatewaySessionsOutput handles inline JSON with escaped quotes and braces in strings', () => {
+  const sessions = [{ sessionId: 'i2c', note: 'literal } and ] and \\"quotes\\"' }];
+  const stdout = `trace: payload ${JSON.stringify({ sessions })} done`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
 test('parseGatewaySessionsOutput extracts data: prefixed JSON array line', () => {
   const sessions = [{ sessionId: 'i3' }];
   const stdout = ['event: snapshot', `data: ${JSON.stringify(sessions)}`].join('\n');

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -73,6 +73,18 @@ test('parseGatewaySessionsOutput strips ANSI color sequences around payload', ()
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput strips UTF-8 BOM from payload output', () => {
+  const sessions = [{ sessionId: 'g-bom' }];
+  const stdout = `\uFEFF${JSON.stringify({ sessions })}`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
+test('parseGatewaySessionsOutput strips zero-width chars from data: line', () => {
+  const sessions = [{ sessionId: 'g-zwsp' }];
+  const stdout = `\u200Bdata:\u2060 ${JSON.stringify({ sessions })}`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
 test('parseGatewaySessionsOutput extracts fenced json payload', () => {
   const sessions = [{ sessionId: 'h' }];
   const stdout = ['logs', '', '```json', JSON.stringify({ sessions }), '```'].join('\n');

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -92,6 +92,16 @@ test('parseGatewaySessionsOutput extracts data: prefixed JSON array line', () =>
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput joins multiline data: payload into valid JSON', () => {
+  const sessions = [{ sessionId: 'i3b' }];
+  const stdout = [
+    'event: message',
+    'data: {"sessions":',
+    `data: ${JSON.stringify(sessions)}}`,
+  ].join('\n');
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
 test('parseGatewaySessionsOutput prefers latest fenced json payload', () => {
   const older = [{ sessionId: 'old' }];
   const latest = [{ sessionId: 'new' }];

--- a/electron/gateway-sessions.test.cjs
+++ b/electron/gateway-sessions.test.cjs
@@ -67,6 +67,12 @@ test('parseGatewaySessionsOutput extracts inline json from log output', () => {
   assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
 });
 
+test('parseGatewaySessionsOutput strips ANSI color sequences around payload', () => {
+  const sessions = [{ sessionId: 'g-ansi' }];
+  const stdout = `\u001b[32mresult:\u001b[0m ${JSON.stringify({ sessions })}`;
+  assert.deepEqual(parseGatewaySessionsOutput(stdout), sessions);
+});
+
 test('parseGatewaySessionsOutput extracts fenced json payload', () => {
   const sessions = [{ sessionId: 'h' }];
   const stdout = ['logs', '', '```json', JSON.stringify({ sessions }), '```'].join('\n');

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -6,6 +6,7 @@ const { createDatabase } = require('./database.cjs');
 const { extractAgentText } = require('./agent-response.cjs');
 const { parseGatewaySessionsOutput } = require('./gateway-sessions.cjs');
 const { summarizeExecError } = require('./cli-error.cjs');
+const { buildAgentCommandArgs } = require('./send-routing.cjs');
 
 const execFileAsync = promisify(execFile);
 
@@ -76,6 +77,13 @@ ipcMain.handle('data:set-composer-drafts', (_event, drafts) => {
   return database.setComposerDrafts(drafts);
 });
 
+ipcMain.handle('data:set-session-agent', (_event, payload) => {
+  return database.setSessionAgent(payload?.sessionId, {
+    agentId: payload?.agentId,
+    agentDisplayName: payload?.agentDisplayName
+  });
+});
+
 ipcMain.handle('settings:get', () => {
   return database.getPreferences();
 });
@@ -101,13 +109,14 @@ ipcMain.handle('data:sync-gateway-sessions', async () => {
 
 ipcMain.handle('data:send-message', async (_event, payload) => {
   const userMessage = database.addMessage(payload);
-
-  const looksLikeGatewaySession = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(payload?.sessionId || '');
+  const routing = database.getSessionRouting(payload?.sessionId);
 
   try {
-    const args = looksLikeGatewaySession
-      ? ['agent', '--session-id', payload.sessionId, '--message', payload.content, '--json']
-      : ['agent', '--agent', 'main', '--message', payload.content, '--json'];
+    const args = buildAgentCommandArgs({
+      sessionId: payload?.sessionId,
+      content: payload?.content,
+      agentId: routing?.agentId
+    });
 
     const { stdout } = await execFileAsync(
       'openclaw',

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -5,6 +5,7 @@ const { promisify } = require('node:util');
 const { createDatabase } = require('./database.cjs');
 const { extractAgentText } = require('./agent-response.cjs');
 const { parseGatewaySessionsOutput } = require('./gateway-sessions.cjs');
+const { parseAgentsListOutput } = require('./agents-list.cjs');
 const { summarizeExecError } = require('./cli-error.cjs');
 const { buildAgentCommandArgs } = require('./send-routing.cjs');
 
@@ -104,6 +105,16 @@ ipcMain.handle('data:sync-gateway-sessions', async () => {
   } catch (error) {
     const reason = summarizeExecError(error, 'Unable to sync sessions');
     throw new Error(`Unable to sync sessions: ${reason}`);
+  }
+});
+
+ipcMain.handle('data:list-agents', async () => {
+  try {
+    const { stdout } = await execFileAsync('openclaw', ['agents', 'list', '--json'], { maxBuffer: 2 * 1024 * 1024 });
+    return parseAgentsListOutput(stdout);
+  } catch (error) {
+    const reason = summarizeExecError(error, 'Unable to list agents');
+    throw new Error(`Unable to list agents: ${reason}`);
   }
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('chatDesktop', {
     getComposerDrafts: () => ipcRenderer.invoke('data:get-composer-drafts'),
     setComposerDrafts: (drafts) => ipcRenderer.invoke('data:set-composer-drafts', drafts),
     setSessionAgent: (payload) => ipcRenderer.invoke('data:set-session-agent', payload),
+    listAgents: () => ipcRenderer.invoke('data:list-agents'),
     reset: () => ipcRenderer.invoke('data:reset'),
     syncGatewaySessions: () => ipcRenderer.invoke('data:sync-gateway-sessions'),
     sendMessage: (payload) => ipcRenderer.invoke('data:send-message', payload)

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('chatDesktop', {
     searchMessages: (query) => ipcRenderer.invoke('data:search', query),
     getComposerDrafts: () => ipcRenderer.invoke('data:get-composer-drafts'),
     setComposerDrafts: (drafts) => ipcRenderer.invoke('data:set-composer-drafts', drafts),
+    setSessionAgent: (payload) => ipcRenderer.invoke('data:set-session-agent', payload),
     reset: () => ipcRenderer.invoke('data:reset'),
     syncGatewaySessions: () => ipcRenderer.invoke('data:sync-gateway-sessions'),
     sendMessage: (payload) => ipcRenderer.invoke('data:send-message', payload)

--- a/electron/send-routing.cjs
+++ b/electron/send-routing.cjs
@@ -1,0 +1,22 @@
+function isGatewaySessionId(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value || '');
+}
+
+function normalizeAgentId(value) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || 'main';
+}
+
+function buildAgentCommandArgs({ sessionId, content, agentId }) {
+  if (isGatewaySessionId(sessionId)) {
+    return ['agent', '--session-id', sessionId, '--message', content, '--json'];
+  }
+
+  return ['agent', '--agent', normalizeAgentId(agentId), '--message', content, '--json'];
+}
+
+module.exports = {
+  isGatewaySessionId,
+  normalizeAgentId,
+  buildAgentCommandArgs
+};

--- a/electron/send-routing.cjs
+++ b/electron/send-routing.cjs
@@ -8,11 +8,19 @@ function normalizeAgentId(value) {
 }
 
 function buildAgentCommandArgs({ sessionId, content, agentId }) {
-  if (isGatewaySessionId(sessionId)) {
-    return ['agent', '--session-id', sessionId, '--message', content, '--json'];
+  const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+
+  if (isGatewaySessionId(normalizedSessionId)) {
+    return ['agent', '--session-id', normalizedSessionId, '--message', content, '--json'];
   }
 
-  return ['agent', '--agent', normalizeAgentId(agentId), '--message', content, '--json'];
+  const args = ['agent', '--agent', normalizeAgentId(agentId)];
+  if (normalizedSessionId) {
+    args.push('--session-id', normalizedSessionId);
+  }
+
+  args.push('--message', content, '--json');
+  return args;
 }
 
 module.exports = {

--- a/electron/send-routing.test.cjs
+++ b/electron/send-routing.test.cjs
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildAgentCommandArgs, normalizeAgentId, isGatewaySessionId } = require('./send-routing.cjs');
+
+test('isGatewaySessionId detects UUID-backed session ids', () => {
+  assert.equal(isGatewaySessionId('d6d72af5-8b93-49ba-8cd3-4449155183ed'), true);
+  assert.equal(isGatewaySessionId('sess-local-1'), false);
+});
+
+test('normalizeAgentId falls back to main for blank values', () => {
+  assert.equal(normalizeAgentId(''), 'main');
+  assert.equal(normalizeAgentId('   '), 'main');
+  assert.equal(normalizeAgentId(undefined), 'main');
+  assert.equal(normalizeAgentId('gpt-5.3'), 'gpt-5.3');
+});
+
+test('buildAgentCommandArgs routes UUID sessions via --session-id', () => {
+  const args = buildAgentCommandArgs({
+    sessionId: 'd6d72af5-8b93-49ba-8cd3-4449155183ed',
+    content: 'hello'
+  });
+
+  assert.deepEqual(args, [
+    'agent',
+    '--session-id',
+    'd6d72af5-8b93-49ba-8cd3-4449155183ed',
+    '--message',
+    'hello',
+    '--json'
+  ]);
+});
+
+test('buildAgentCommandArgs routes local sessions via selected agent', () => {
+  const args = buildAgentCommandArgs({
+    sessionId: 'sess-local-1',
+    content: 'hello',
+    agentId: 'openai/gpt-5.3-codex'
+  });
+
+  assert.deepEqual(args, [
+    'agent',
+    '--agent',
+    'openai/gpt-5.3-codex',
+    '--message',
+    'hello',
+    '--json'
+  ]);
+});

--- a/electron/send-routing.test.cjs
+++ b/electron/send-routing.test.cjs
@@ -30,7 +30,7 @@ test('buildAgentCommandArgs routes UUID sessions via --session-id', () => {
   ]);
 });
 
-test('buildAgentCommandArgs routes local sessions via selected agent', () => {
+test('buildAgentCommandArgs routes local sessions via selected agent and preserves session continuity', () => {
   const args = buildAgentCommandArgs({
     sessionId: 'sess-local-1',
     content: 'hello',
@@ -41,6 +41,25 @@ test('buildAgentCommandArgs routes local sessions via selected agent', () => {
     'agent',
     '--agent',
     'openai/gpt-5.3-codex',
+    '--session-id',
+    'sess-local-1',
+    '--message',
+    'hello',
+    '--json'
+  ]);
+});
+
+test('buildAgentCommandArgs omits --session-id for blank local ids', () => {
+  const args = buildAgentCommandArgs({
+    sessionId: '   ',
+    content: 'hello',
+    agentId: 'main'
+  });
+
+  assert.deepEqual(args, [
+    'agent',
+    '--agent',
+    'main',
     '--message',
     'hello',
     '--json'

--- a/electron/send-routing.test.cjs
+++ b/electron/send-routing.test.cjs
@@ -30,6 +30,22 @@ test('buildAgentCommandArgs routes UUID sessions via --session-id', () => {
   ]);
 });
 
+test('buildAgentCommandArgs trims UUID session ids before routing', () => {
+  const args = buildAgentCommandArgs({
+    sessionId: '  d6d72af5-8b93-49ba-8cd3-4449155183ed  ',
+    content: 'hello'
+  });
+
+  assert.deepEqual(args, [
+    'agent',
+    '--session-id',
+    'd6d72af5-8b93-49ba-8cd3-4449155183ed',
+    '--message',
+    'hello',
+    '--json'
+  ]);
+});
+
 test('buildAgentCommandArgs routes local sessions via selected agent and preserves session continuity', () => {
   const args = buildAgentCommandArgs({
     sessionId: 'sess-local-1',

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -87,6 +87,7 @@
   let preferences = { gatewayUrl: 'http://localhost:4111', theme: 'system' };
   let syncInFlight = false;
   let lastSyncedAt = null;
+  let showGatewayDetails = false;
   let heartbeatTimer;
   let copyChatIdState = 'idle';
   let copyChatIdTimer;
@@ -1004,12 +1005,11 @@
 </script>
 
 <div class="app-frame">
-  <header class="top-bar">
-    <div class="gateway-compact">
-      <span class="meta">Gateway</span>
+  <header class="top-bar compact">
+    <button class="ghost gateway-toggle" on:click={() => (showGatewayDetails = !showGatewayDetails)}>
       <span class={`pill ${gatewayStatusPill.tone}`}>{gatewayStatusPill.label}</span>
-      <span class="meta">{gateway.heartbeat}</span>
-    </div>
+      <span class="meta">Gateway · {gateway.heartbeat}</span>
+    </button>
     <div class="top-actions compact">
       <button class="ghost" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
         {syncInFlight ? 'Syncing…' : 'Sync'}
@@ -1018,6 +1018,14 @@
       <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
     </div>
   </header>
+
+  {#if showGatewayDetails}
+    <section class="gateway-details" aria-label="Gateway details">
+      <strong>{gateway.name}</strong>
+      <span class="meta">{gateway.endpoint}</span>
+      <span class="meta">Last heartbeat · {gateway.heartbeat}</span>
+    </section>
+  {/if}
 
   <div class={`shell-grid ${chatRailOpen ? '' : 'chat-rail-collapsed'} ${sideRailOpen ? '' : 'side-rail-collapsed'}`}>
     <aside class="chat-rail" aria-label="Chat list">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,8 +74,10 @@
   let highlightTimeout;
   let draftPersistTimer;
   let showSettings = false;
-  let chatRailOpen = false;
+  let chatRailOpen = true;
   let sideRailOpen = false;
+  let leftNav = 'chats';
+  let openChatMenuId = null;
   let settingsSaving = false;
   let resettingData = false;
   let sendingMessage = false;
@@ -94,6 +96,7 @@
 
   onMount(async () => {
     const removeKeydown = bindKeyboardShortcuts();
+    const removeOutsideClick = bindOutsideClick();
     await Promise.all([
       hydrateFromDatabase(),
       hydrateAppMeta(),
@@ -113,6 +116,7 @@
       if (draftPersistTimer) clearTimeout(draftPersistTimer);
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
+      removeOutsideClick?.();
       removeKeydown?.();
     };
   });
@@ -303,8 +307,7 @@
     await hydrateGatewaySessions();
   }
 
-  async function copyCurrentChatId() {
-    const chatId = selectedSession?.id;
+  async function copyCurrentChatId(chatId = selectedSession?.id) {
     if (!chatId) {
       copyChatIdState = 'error';
       if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
@@ -668,6 +671,52 @@
     return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
   }
 
+  function bindOutsideClick() {
+    if (typeof window === 'undefined') return null;
+    const onPointerDown = () => {
+      openChatMenuId = null;
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => window.removeEventListener('pointerdown', onPointerDown);
+  }
+
+  function createNewChat() {
+    const now = new Date();
+    const localId = `local-${now.getTime()}`;
+    const timestamp = new Intl.DateTimeFormat('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: 'Europe/London'
+    }).format(now);
+
+    const template = sections[0]?.sessions[0];
+    const nextChat = {
+      id: localId,
+      name: 'New chat',
+      preview: 'Start the conversation…',
+      channel: template?.channel || 'Desktop',
+      chip: template?.chip || 'local',
+      status: 'muted',
+      unread: 0,
+      lastMessageAt: timestamp,
+      agentId: template?.agentId || 'main',
+      agentDisplayName: template?.agentDisplayName || 'Primary'
+    };
+
+    sections = sections.map((section, index) => (
+      index === 0 ? { ...section, sessions: [nextChat, ...section.sessions] } : section
+    ));
+
+    openChatMenuId = null;
+    void selectSession(localId);
+  }
+
+  function toggleChatMenu(event, sessionId) {
+    event.stopPropagation();
+    openChatMenuId = openChatMenuId === sessionId ? null : sessionId;
+  }
+
   function bindKeyboardShortcuts() {
     if (typeof window === 'undefined') return null;
 
@@ -978,36 +1027,84 @@
 
   <div class={`shell-grid ${chatRailOpen ? '' : 'chat-rail-collapsed'} ${sideRailOpen ? '' : 'side-rail-collapsed'}`}>
     <aside class="chat-rail" aria-label="Chat list">
-      {#each sections as section}
-        <div class="chat-section">
-          <p class="section-label">{section.title}</p>
-          {#each section.sessions as session}
-            <button
-              class={`chat-tile ${session.id === selectedSessionId ? 'active' : ''}`}
-              on:click={() => selectSession(session.id)}
-            >
-              <div class="tile-main">
-                <div>
-                  <div class="name-row">
-                    <span class="name">{session.name}</span>
-                    {#if session.unread}
-                      <span class="badge">{session.unread}</span>
-                    {/if}
+      <div class="chat-rail-header">
+        <strong>OpenClaw Chat</strong>
+        <button class="ghost rail-collapse" on:click={() => (chatRailOpen = false)}>Hide</button>
+      </div>
+      <button class="primary new-chat" on:click={createNewChat}>New chat</button>
+
+      <div class="left-nav" role="tablist" aria-label="Primary navigation">
+        <button class={leftNav === 'chats' ? 'active' : ''} on:click={() => (leftNav = 'chats')}>Chats</button>
+        <button class={leftNav === 'agents' ? 'active' : ''} on:click={() => (leftNav = 'agents')}>Agents</button>
+      </div>
+
+      {#if leftNav === 'agents'}
+        <div class="agent-list">
+          {#if availableAgents.length}
+            {#each availableAgents as agent}
+              <div class="agent-row">
+                <strong>{agent.displayName || agent.id}</strong>
+                <span class="meta">{agent.id}</span>
+              </div>
+            {/each}
+          {:else}
+            <p class="meta">No agents loaded.</p>
+          {/if}
+        </div>
+      {:else}
+        <p class="section-label">Recent chats</p>
+        {#each sections as section}
+          <div class="chat-section">
+            {#each section.sessions as session}
+              <div
+                class={`chat-tile ${session.id === selectedSessionId ? 'active' : ''}`}
+                role="button"
+                tabindex="0"
+                on:click={() => selectSession(session.id)}
+                on:keydown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    selectSession(session.id);
+                  }
+                }}
+              >
+                <div class="tile-main">
+                  <div>
+                    <div class="name-row">
+                      <span class="name">{session.name}</span>
+                      {#if session.unread}
+                        <span class="badge">{session.unread}</span>
+                      {/if}
+                    </div>
+                    <p class="preview">{session.preview}</p>
+                    <p class="meta tile-time">{session.lastMessageAt || 'Unknown activity'}</p>
                   </div>
-                  <p class="preview">{session.preview}</p>
+                  <div class="tile-meta">
+                    <span class={`chip ${session.chip}`}>{session.channel}</span>
+                    <span class="agent-pill" title={`Agent: ${session.agentId || 'main'}`}>
+                      {session.agentDisplayName || session.agentId || 'Primary'}
+                    </span>
+                  </div>
                 </div>
-                <div class="tile-meta">
-                  <span class={`chip ${session.chip}`}>{session.channel}</span>
-                  <span class="agent-pill" title={`Agent: ${session.agentId || 'main'}`}>
-                    {session.agentDisplayName || session.agentId || 'Primary'}
-                  </span>
+                <div class="tile-actions">
+                  <button class="ghost overflow" aria-label="Chat actions" on:click={(event) => toggleChatMenu(event, session.id)}>⋯</button>
+                  {#if openChatMenuId === session.id}
+                    <div class="chat-menu" role="menu" tabindex="-1" aria-label="Chat actions" on:pointerdown|stopPropagation>
+                      <button class="ghost" on:click={() => { copyCurrentChatId(session.id); openChatMenuId = null; }}>Copy chat ID</button>
+                      <button class="ghost" on:click={() => { openChatMenuId = null; }}>Mute chat</button>
+                    </div>
+                  {/if}
+                  <span class={`status-dot ${session.status}`}></span>
                 </div>
               </div>
-              <span class={`status-dot ${session.status}`}></span>
-            </button>
-          {/each}
-        </div>
-      {/each}
+            {/each}
+          </div>
+        {/each}
+      {/if}
+
+      <footer class="chat-rail-footer">
+        <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
+      </footer>
     </aside>
 
     <section class="timeline-area" aria-label="Conversation timeline">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,6 +14,7 @@
   let routingAgentDisplayName = 'Primary';
   let routingSaving = false;
   let availableAgents = [];
+  let agentsLoading = false;
 
   const runs = [
     {
@@ -176,8 +177,11 @@
   }
 
   async function hydrateAvailableAgents() {
+    agentsLoading = true;
+
     if (!dataClient?.listAgents) {
       availableAgents = [{ id: 'main', displayName: 'Primary', model: '' }];
+      agentsLoading = false;
       return;
     }
 
@@ -191,6 +195,8 @@
     } catch (error) {
       console.error('Unable to load agents list', error);
       availableAgents = [{ id: 'main', displayName: 'Primary', model: '' }];
+    } finally {
+      agentsLoading = false;
     }
   }
 
@@ -355,11 +361,16 @@
 
     routingSaving = true;
     errorMessage = '';
+
+    const normalizedAgentId = typeof routingAgentId === 'string' ? routingAgentId.trim() : '';
+    const matchingAgent = availableAgents.find((agent) => agent.id === normalizedAgentId);
+    const normalizedDisplayName = typeof routingAgentDisplayName === 'string' ? routingAgentDisplayName.trim() : '';
+
     try {
       const updated = await dataClient.setSessionAgent({
         sessionId: selectedSessionId,
-        agentId: routingAgentId,
-        agentDisplayName: routingAgentDisplayName
+        agentId: normalizedAgentId || 'main',
+        agentDisplayName: normalizedDisplayName || matchingAgent?.displayName || normalizedAgentId || 'Primary'
       });
 
       sections = sections.map((section) => ({
@@ -1008,9 +1019,14 @@
                 {#if availableAgents.length}
                   <p class="meta">Available agents: {availableAgents.map((agent) => agent.id).join(', ')}</p>
                 {/if}
-                <button class="primary" on:click={saveSessionRouting} disabled={routingSaving}>
-                  {routingSaving ? 'Saving…' : 'Save routing'}
-                </button>
+                <div class="composer-controls">
+                  <button class="ghost" on:click={() => hydrateAvailableAgents()} disabled={agentsLoading}>
+                    {agentsLoading ? 'Refreshing…' : 'Refresh agents'}
+                  </button>
+                  <button class="primary" on:click={saveSessionRouting} disabled={routingSaving}>
+                    {routingSaving ? 'Saving…' : 'Save routing'}
+                  </button>
+                </div>
               </div>
             {/if}
           {:else if activeRightTab === 'runs'}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
   let routingAgentId = 'main';
   let routingAgentDisplayName = 'Primary';
   let routingSaving = false;
+  let availableAgents = [];
 
   const runs = [
     {
@@ -88,7 +89,13 @@
 
   onMount(async () => {
     const removeKeydown = bindKeyboardShortcuts();
-    await Promise.all([hydrateFromDatabase(), hydrateAppMeta(), hydratePreferences(), hydrateComposerDrafts()]);
+    await Promise.all([
+      hydrateFromDatabase(),
+      hydrateAppMeta(),
+      hydratePreferences(),
+      hydrateComposerDrafts(),
+      hydrateAvailableAgents()
+    ]);
     await hydrateGatewaySessions({ silentError: true });
     heartbeatTimer = setInterval(() => {
       refreshHeartbeatLabel();
@@ -165,6 +172,25 @@
       restoreDraftForSession(selectedSessionId);
     } catch (error) {
       console.error('Unable to load composer drafts', error);
+    }
+  }
+
+  async function hydrateAvailableAgents() {
+    if (!dataClient?.listAgents) {
+      availableAgents = [{ id: 'main', displayName: 'Primary', model: '' }];
+      return;
+    }
+
+    try {
+      const rows = await dataClient.listAgents();
+      if (Array.isArray(rows) && rows.length) {
+        availableAgents = rows;
+      } else {
+        availableAgents = [{ id: 'main', displayName: 'Primary', model: '' }];
+      }
+    } catch (error) {
+      console.error('Unable to load agents list', error);
+      availableAgents = [{ id: 'main', displayName: 'Primary', model: '' }];
     }
   }
 
@@ -972,8 +998,16 @@
                 </label>
                 <label>
                   <span>Agent ID</span>
-                  <input type="text" bind:value={routingAgentId} placeholder="main" />
+                  <input type="text" bind:value={routingAgentId} placeholder="main" list="agent-id-suggestions" />
                 </label>
+                <datalist id="agent-id-suggestions">
+                  {#each availableAgents as agent}
+                    <option value={agent.id}>{agent.displayName}</option>
+                  {/each}
+                </datalist>
+                {#if availableAgents.length}
+                  <p class="meta">Available agents: {availableAgents.map((agent) => agent.id).join(', ')}</p>
+                {/if}
                 <button class="primary" on:click={saveSessionRouting} disabled={routingSaving}>
                   {routingSaving ? 'Saving…' : 'Save routing'}
                 </button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -287,7 +287,7 @@
 
   async function copyCurrentChatId() {
     const chatId = selectedSession?.id;
-    if (!chatId || !navigator?.clipboard?.writeText) {
+    if (!chatId) {
       copyChatIdState = 'error';
       if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
       copyChatIdTimer = setTimeout(() => {
@@ -297,7 +297,24 @@
     }
 
     try {
-      await navigator.clipboard.writeText(chatId);
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(chatId);
+      } else {
+        const scratch = document.createElement('textarea');
+        scratch.value = chatId;
+        scratch.setAttribute('readonly', 'true');
+        scratch.style.position = 'fixed';
+        scratch.style.opacity = '0';
+        document.body.appendChild(scratch);
+        scratch.select();
+        scratch.setSelectionRange(0, scratch.value.length);
+        const copied = document.execCommand('copy');
+        document.body.removeChild(scratch);
+        if (!copied) {
+          throw new Error('execCommand copy returned false');
+        }
+      }
+
       copyChatIdState = 'copied';
     } catch (error) {
       console.error('Unable to copy chat id', error);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,6 +60,7 @@
   let sections = buildSectionsFromSeed();
   let selectedSessionId = sections[0]?.sessions[0]?.id ?? null;
   let messages = buildMessagesFromSeed(selectedSessionId);
+  maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
   let selectedSession = findSession(selectedSessionId);
   let activeRightTab = 'context';
   let composerValue = '';
@@ -120,6 +121,7 @@
       messages = payload.messages?.length ? payload.messages : buildMessagesFromSeed(selectedSessionId);
       selectedSession = findSession(selectedSessionId);
       restoreDraftForSession(selectedSessionId);
+      maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
     } catch (error) {
       console.error('Failed to read persisted conversations', error);
       errorMessage = 'Unable to open the stored SQLite cache. Showing demo data instead.';
@@ -127,6 +129,7 @@
       selectedSessionId = sections[0]?.sessions[0]?.id ?? null;
       messages = buildMessagesFromSeed(selectedSessionId);
       restoreDraftForSession(selectedSessionId);
+      maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
     } finally {
       loading = false;
     }
@@ -192,6 +195,7 @@
         if (selectedSessionId) {
           const client = dataClient ?? fallbackAdapter;
           messages = await client.getMessages(selectedSessionId);
+          maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
         } else {
           messages = [];
         }
@@ -280,6 +284,7 @@
       sessionDrafts = {};
       queuePersistDrafts();
       restoreDraftForSession(selectedSessionId);
+      maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
       errorMessage = '';
       searchQuery = '';
       searchResults = [];
@@ -303,10 +308,12 @@
     try {
       const client = dataClient ?? fallbackAdapter;
       messages = await client.getMessages(sessionId);
+      maybeHydrateChatTitleFromMessages(sessionId, messages);
     } catch (error) {
       console.error('Failed to load messages', error);
       errorMessage = 'Unable to load messages for that chat. Showing offline data if available.';
       messages = buildMessagesFromSeed(sessionId);
+      maybeHydrateChatTitleFromMessages(sessionId, messages);
     }
 
     searchQuery = '';
@@ -354,6 +361,41 @@
 
       return { ...section, sessions: nextSessions };
     });
+  }
+
+  function deriveChatTitleFromMessages(messageList = []) {
+    if (!Array.isArray(messageList)) {
+      return null;
+    }
+
+    const firstUserMessage = messageList.find(
+      (message) =>
+        message &&
+        typeof message.content === 'string' &&
+        message.content.trim() &&
+        typeof message.role === 'string' &&
+        message.role.toLowerCase() === 'user'
+    );
+
+    return firstUserMessage ? generateChatTitle(firstUserMessage.content) : null;
+  }
+
+  function maybeHydrateChatTitleFromMessages(sessionId, messageList) {
+    if (!sessionId || !Array.isArray(messageList) || !messageList.length) {
+      return;
+    }
+
+    const session = findSession(sessionId);
+    if (!session || !isUntitledChat(session.name)) {
+      return;
+    }
+
+    const generatedTitle = deriveChatTitleFromMessages(messageList);
+    if (!generatedTitle) {
+      return;
+    }
+
+    updateSessionTitle(sessionId, generatedTitle);
   }
 
   async function sendCurrentMessage() {
@@ -713,13 +755,13 @@
   </header>
 
   <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'}`}>
-    <aside class="session-rail" aria-label="Chat list">
+    <aside class="chat-rail" aria-label="Chat list">
       {#each sections as section}
-        <div class="session-section">
+        <div class="chat-section">
           <p class="section-label">{section.title}</p>
           {#each section.sessions as session}
             <button
-              class={`session-tile ${session.id === selectedSessionId ? 'active' : ''}`}
+              class={`chat-tile ${session.id === selectedSessionId ? 'active' : ''}`}
               on:click={() => selectSession(session.id)}
             >
               <div class="tile-main">
@@ -775,7 +817,7 @@
           {:else}
             {#each searchResults as result}
               <button class="search-hit" on:click={() => jumpToSearchResult(result)}>
-                <span class="hit-session">{result.sessionName} · {result.sessionChannel}</span>
+                <span class="hit-chat">{result.sessionName} · {result.sessionChannel}</span>
                 <span class="hit-excerpt" aria-label={`Snippet from ${result.author}`}>
                   {@html result.snippet}
                 </span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -207,7 +207,7 @@
       console.error('Unable to sync gateway sessions', error);
       gateway = { ...gateway, status: 'offline' };
       if (!silentError) {
-        errorMessage = error?.message || 'Unable to sync gateway sessions.';
+        errorMessage = error?.message || 'Unable to sync gateway chats.';
       }
     } finally {
       syncInFlight = false;
@@ -315,6 +315,32 @@
     restoreDraftForSession(sessionId);
   }
 
+  function generateChatTitle(input) {
+    const trimmed = typeof input === 'string' ? input.trim() : '';
+    return trimmed ? trimmed.slice(0, 72) : 'New chat';
+  }
+
+  function isUntitledChat(name) {
+    const normalized = typeof name === 'string' ? name.trim().toLowerCase() : '';
+    return !normalized || normalized === 'new chat';
+  }
+
+  function updateSessionTitle(sessionId, messageContent) {
+    const generatedTitle = generateChatTitle(messageContent);
+    sections = sections.map((section) => {
+      const hasSession = section.sessions.some((session) => session.id === sessionId);
+      if (!hasSession) return section;
+
+      const nextSessions = section.sessions.map((session) => (
+        session.id === sessionId && isUntitledChat(session.name)
+          ? { ...session, name: generatedTitle }
+          : session
+      ));
+
+      return { ...section, sessions: nextSessions };
+    });
+  }
+
   function updateSessionPreview(sessionId, preview) {
     sections = sections.map((section) => {
       const hasSession = section.sessions.some((session) => session.id === sessionId);
@@ -335,7 +361,7 @@
     if (!selectedSessionId || !content || sendingMessage) return;
 
     if (isGatewaySessionId(selectedSessionId) && gateway.status === 'offline') {
-      errorMessage = 'Gateway is offline. Reconnect or sync sessions before sending.';
+      errorMessage = 'Gateway is offline. Reconnect or sync chats before sending.';
       return;
     }
 
@@ -356,6 +382,7 @@
       messages = incoming ? [...messages, outgoing, incoming] : [...messages, outgoing];
       composerValue = '';
       persistDraftForSession(selectedSessionId, '');
+      updateSessionTitle(selectedSessionId, content);
       updateSessionPreview(selectedSessionId, incoming?.content || content);
       await tick();
       highlightMessage((incoming || outgoing)?.id);
@@ -563,7 +590,7 @@
           return {
             id: message.id,
             sessionId: message.sessionId,
-            sessionName: session?.name ?? 'Session',
+            sessionName: session?.name ?? 'Chat',
             sessionChannel: session?.channel ?? 'Channel',
             author: message.author,
             role: message.role,
@@ -660,7 +687,7 @@
   $: sendDisabled = !composerValue.trim() || sendingMessage || (selectedSessionIsGateway && gateway.status === 'offline');
   $: composerGatewayStatus = selectedSessionIsGateway
     ? (gateway.status === 'offline' ? 'Gateway offline' : `Gateway ${gateway.status}`)
-    : 'Local session';
+    : 'Local chat';
 </script>
 
 <div class="app-frame">
@@ -773,7 +800,7 @@
       {#if loading}
         <div class="loading-state">Loading conversation…</div>
       {:else if !messages.length}
-        <div class="empty-state">No messages in this session yet.</div>
+        <div class="empty-state">No messages in this chat yet.</div>
       {:else}
         <div class="message-list">
           {#each messages as message}
@@ -828,7 +855,7 @@
     </section>
 
     {#if sideRailOpen}
-      <aside class="side-rail" aria-label="Session context">
+      <aside class="side-rail" aria-label="Chat context">
         <div class="tab-strip">
           {#each rightTabs as tab}
             <button

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,6 +74,7 @@
   let highlightTimeout;
   let draftPersistTimer;
   let showSettings = false;
+  let chatRailOpen = false;
   let sideRailOpen = false;
   let settingsSaving = false;
   let resettingData = false;
@@ -711,6 +712,12 @@
         return;
       }
 
+      if (event.shiftKey && event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        chatRailOpen = !chatRailOpen;
+        return;
+      }
+
       if (event.shiftKey && event.key === '[') {
         event.preventDefault();
         selectAdjacentSession(-1);
@@ -960,7 +967,7 @@
     </div>
   </header>
 
-  <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'}`}>
+  <div class={`shell-grid ${chatRailOpen ? '' : 'chat-rail-collapsed'} ${sideRailOpen ? '' : 'side-rail-collapsed'}`}>
     <aside class="chat-rail" aria-label="Chat list">
       {#each sections as section}
         <div class="chat-section">
@@ -1016,6 +1023,9 @@
           />
           <button class="ghost" on:click={focusSearchInput}>Jump ⌘K</button>
           <button class="ghost" on:click={focusComposerInput}>Compose ⌘⇧L</button>
+          <button class="ghost" on:click={() => (chatRailOpen = !chatRailOpen)}>
+            {chatRailOpen ? 'Hide chats' : 'Show chats'}
+          </button>
           <button class="ghost" on:click={() => (sideRailOpen = !sideRailOpen)}>
             {sideRailOpen ? 'Hide panel' : 'Show panel'}
           </button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -362,15 +362,13 @@
     routingSaving = true;
     errorMessage = '';
 
-    const normalizedAgentId = typeof routingAgentId === 'string' ? routingAgentId.trim() : '';
-    const matchingAgent = availableAgents.find((agent) => agent.id === normalizedAgentId);
-    const normalizedDisplayName = typeof routingAgentDisplayName === 'string' ? routingAgentDisplayName.trim() : '';
+    const matchingAgent = availableAgents.find((agent) => agent.id === normalizedRoutingAgentId);
 
     try {
       const updated = await dataClient.setSessionAgent({
         sessionId: selectedSessionId,
-        agentId: normalizedAgentId || 'main',
-        agentDisplayName: normalizedDisplayName || matchingAgent?.displayName || normalizedAgentId || 'Primary'
+        agentId: normalizedRoutingAgentId,
+        agentDisplayName: normalizedRoutingDisplayName || matchingAgent?.displayName || normalizedRoutingAgentId
       });
 
       sections = sections.map((section) => ({
@@ -379,8 +377,8 @@
           session.id === selectedSessionId
             ? {
               ...session,
-              agentId: updated?.agentId || routingAgentId || 'main',
-              agentDisplayName: updated?.agentDisplayName || routingAgentDisplayName || 'Primary'
+              agentId: updated?.agentId || normalizedRoutingAgentId,
+              agentDisplayName: updated?.agentDisplayName || normalizedRoutingDisplayName
             }
             : session
         ))
@@ -797,6 +795,12 @@
 
   $: selectedSession = findSession(selectedSessionId);
   $: syncRoutingDraftFromSession(selectedSession);
+  $: normalizedRoutingAgentId = (routingAgentId || '').trim() || 'main';
+  $: normalizedRoutingDisplayName = (routingAgentDisplayName || '').trim() || normalizedRoutingAgentId;
+  $: routingDirty = Boolean(selectedSession) && (
+    normalizedRoutingAgentId !== (selectedSession?.agentId || 'main') ||
+    normalizedRoutingDisplayName !== (selectedSession?.agentDisplayName || 'Primary')
+  );
   $: selectedSessionIsGateway = isGatewaySessionId(selectedSessionId);
   $: sendDisabled = !composerValue.trim() || sendingMessage || (selectedSessionIsGateway && gateway.status === 'offline');
   $: composerGatewayStatus = selectedSessionIsGateway
@@ -1023,7 +1027,14 @@
                   <button class="ghost" on:click={() => hydrateAvailableAgents()} disabled={agentsLoading}>
                     {agentsLoading ? 'Refreshing…' : 'Refresh agents'}
                   </button>
-                  <button class="primary" on:click={saveSessionRouting} disabled={routingSaving}>
+                  <button
+                    class="ghost"
+                    on:click={() => syncRoutingDraftFromSession(selectedSession)}
+                    disabled={!routingDirty || routingSaving}
+                  >
+                    Revert
+                  </button>
+                  <button class="primary" on:click={saveSessionRouting} disabled={routingSaving || !routingDirty}>
                     {routingSaving ? 'Saving…' : 'Save routing'}
                   </button>
                 </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -84,6 +84,8 @@
   let syncInFlight = false;
   let lastSyncedAt = null;
   let heartbeatTimer;
+  let copyChatIdState = 'idle';
+  let copyChatIdTimer;
 
   const chatDesktop = typeof window !== 'undefined' ? window.chatDesktop : undefined;
   const dataClient = chatDesktop?.data;
@@ -108,6 +110,7 @@
       if (highlightTimeout) clearTimeout(highlightTimeout);
       if (draftPersistTimer) clearTimeout(draftPersistTimer);
       if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
       removeKeydown?.();
     };
   });
@@ -282,6 +285,31 @@
     await hydrateGatewaySessions();
   }
 
+  async function copyCurrentChatId() {
+    const chatId = selectedSession?.id;
+    if (!chatId || !navigator?.clipboard?.writeText) {
+      copyChatIdState = 'error';
+      if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
+      copyChatIdTimer = setTimeout(() => {
+        copyChatIdState = 'idle';
+      }, 2000);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(chatId);
+      copyChatIdState = 'copied';
+    } catch (error) {
+      console.error('Unable to copy chat id', error);
+      copyChatIdState = 'error';
+    }
+
+    if (copyChatIdTimer) clearTimeout(copyChatIdTimer);
+    copyChatIdTimer = setTimeout(() => {
+      copyChatIdState = 'idle';
+    }, 2000);
+  }
+
   function applyTheme(theme) {
     if (typeof document === 'undefined') return;
     const resolved = theme === 'system'
@@ -339,6 +367,7 @@
     persistDraftForSession(selectedSessionId, composerValue);
     selectedSessionId = sessionId;
     selectedSession = findSession(sessionId);
+    copyChatIdState = 'idle';
     syncRoutingDraftFromSession(selectedSession);
     try {
       const client = dataClient ?? fallbackAdapter;
@@ -1069,6 +1098,9 @@
                   <p class="meta">Available agents: {availableAgents.map((agent) => agent.id).join(', ')}</p>
                 {/if}
                 <div class="composer-controls">
+                  <button class="ghost" on:click={copyCurrentChatId}>
+                    {copyChatIdState === 'copied' ? 'Copied chat ID' : copyChatIdState === 'error' ? 'Copy failed' : 'Copy chat ID'}
+                  </button>
                   <button class="ghost" on:click={() => hydrateAvailableAgents()} disabled={agentsLoading}>
                     {agentsLoading ? 'Refreshing…' : 'Refresh agents'}
                   </button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -606,6 +606,18 @@
         return;
       }
 
+      if (event.key === ',') {
+        event.preventDefault();
+        showSettings = true;
+        return;
+      }
+
+      if (event.shiftKey && event.key.toLowerCase() === 'r') {
+        event.preventDefault();
+        void hydrateGatewaySessions();
+        return;
+      }
+
       if (event.shiftKey && event.key === '[') {
         event.preventDefault();
         selectAdjacentSession(-1);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -573,10 +573,17 @@
     }
   }
 
+  function isEditableShortcutTarget(target) {
+    if (!target || typeof target.closest !== 'function') return false;
+    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+  }
+
   function bindKeyboardShortcuts() {
     if (typeof window === 'undefined') return null;
 
     const onKeydown = (event) => {
+      const isEditableTarget = isEditableShortcutTarget(event.target);
+
       if (event.key === 'Escape') {
         if (showSettings) {
           event.preventDefault();
@@ -584,7 +591,7 @@
           return;
         }
 
-        if (sideRailOpen) {
+        if (!isEditableTarget && sideRailOpen) {
           event.preventDefault();
           sideRailOpen = false;
         }
@@ -592,7 +599,7 @@
       }
 
       const hasPrimaryModifier = event.metaKey || event.ctrlKey;
-      if (!hasPrimaryModifier) return;
+      if (!hasPrimaryModifier || isEditableTarget) return;
 
       if (event.key.toLowerCase() === 'k') {
         event.preventDefault();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -126,6 +126,8 @@
       selectedSession = findSession(selectedSessionId);
       restoreDraftForSession(selectedSessionId);
       maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
+      await tick();
+      scrollToLatestMessage();
     } catch (error) {
       console.error('Failed to read persisted conversations', error);
       errorMessage = 'Unable to open the stored SQLite cache. Showing demo data instead.';
@@ -134,6 +136,8 @@
       messages = buildMessagesFromSeed(selectedSessionId);
       restoreDraftForSession(selectedSessionId);
       maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
+      await tick();
+      scrollToLatestMessage();
     } finally {
       loading = false;
     }
@@ -224,6 +228,8 @@
           const client = dataClient ?? fallbackAdapter;
           messages = await client.getMessages(selectedSessionId);
           maybeHydrateChatTitleFromMessages(selectedSessionId, messages);
+          await tick();
+          scrollToLatestMessage();
         } else {
           messages = [];
         }
@@ -338,11 +344,15 @@
       const client = dataClient ?? fallbackAdapter;
       messages = await client.getMessages(sessionId);
       maybeHydrateChatTitleFromMessages(sessionId, messages);
+      await tick();
+      scrollToLatestMessage();
     } catch (error) {
       console.error('Failed to load messages', error);
       errorMessage = 'Unable to load messages for that chat. Showing offline data if available.';
       messages = buildMessagesFromSeed(sessionId);
       maybeHydrateChatTitleFromMessages(sessionId, messages);
+      await tick();
+      scrollToLatestMessage();
     }
 
     searchQuery = '';
@@ -785,6 +795,13 @@
     await selectSession(result.sessionId);
     await tick();
     highlightMessage(result.id);
+  }
+
+  function scrollToLatestMessage({ smooth = false } = {}) {
+    if (typeof document === 'undefined') return;
+    const node = document.querySelector('.message-list article:last-child');
+    if (!node) return;
+    node.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'end' });
   }
 
   function highlightMessage(messageId) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -860,7 +860,12 @@
                   </div>
                   <p class="preview">{session.preview}</p>
                 </div>
-                <span class={`chip ${session.chip}`}>{session.channel}</span>
+                <div class="tile-meta">
+                  <span class={`chip ${session.chip}`}>{session.channel}</span>
+                  <span class="agent-pill" title={`Agent: ${session.agentId || 'main'}`}>
+                    {session.agentDisplayName || session.agentId || 'Primary'}
+                  </span>
+                </div>
               </div>
               <span class={`status-dot ${session.status}`}></span>
             </button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -846,6 +846,13 @@
     searchDebounce = setTimeout(runSearch, 200);
   }
 
+  function handleSearchKeydown(event) {
+    if (event.key !== 'Enter') return;
+    if (!searchQuery.trim() || searchStatus === 'loading' || !searchResults.length) return;
+    event.preventDefault();
+    void jumpToSearchResult(searchResults[0]);
+  }
+
   async function runSearch() {
     if (!searchQuery.trim()) {
       searchResults = [];
@@ -1005,6 +1012,7 @@
             value={searchQuery}
             bind:this={searchInputEl}
             on:input={handleSearchInput}
+            on:keydown={handleSearchKeydown}
           />
           <button class="ghost" on:click={focusSearchInput}>Jump ⌘K</button>
           <button class="ghost" on:click={focusComposerInput}>Compose ⌘⇧L</button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1005,23 +1005,17 @@
 
 <div class="app-frame">
   <header class="top-bar">
-    <div class="gateway">
-      <div>
-        <p class="eyebrow">Gateway</p>
-        <strong>{gateway.name}</strong>
-      </div>
-      <div class="gateway-meta">
-        <span class={`pill ${gatewayStatusPill.tone}`}>{gatewayStatusPill.label}</span>
-        <span class="meta">{gateway.endpoint}</span>
-        <span class="meta">Last heartbeat · {gateway.heartbeat}</span>
-      </div>
+    <div class="gateway-compact">
+      <span class="meta">Gateway</span>
+      <span class={`pill ${gatewayStatusPill.tone}`}>{gatewayStatusPill.label}</span>
+      <span class="meta">{gateway.heartbeat}</span>
     </div>
-    <div class="top-actions">
-      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
-      <button class="ghost" on:click={openLogsFolder}>Open logs</button>
-      <button class="primary" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
-        {syncInFlight ? 'Syncing…' : 'Sync chats'}
+    <div class="top-actions compact">
+      <button class="ghost" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
+        {syncInFlight ? 'Syncing…' : 'Sync'}
       </button>
+      <button class="ghost" on:click={openLogsFolder}>Logs</button>
+      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
     </div>
   </header>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,7 +74,7 @@
   let highlightTimeout;
   let draftPersistTimer;
   let showSettings = false;
-  let sideRailOpen = true;
+  let sideRailOpen = false;
   let settingsSaving = false;
   let resettingData = false;
   let sendingMessage = false;
@@ -891,6 +891,9 @@
         <div>
           <p class="eyebrow">Current chat</p>
           <h2>{selectedSession?.name ?? 'Chat'}</h2>
+          <span class="header-agent-pill" title={`Agent: ${selectedSession?.agentId || 'main'}`}>
+            Agent · {selectedSession?.agentDisplayName || selectedSession?.agentId || 'Primary'}
+          </span>
         </div>
         <div class="timeline-actions">
           <input

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -465,6 +465,15 @@
     }
   }
 
+  async function quickSwitchHeaderAgent(event) {
+    const nextAgentId = event.currentTarget.value;
+    if (!nextAgentId || nextAgentId === normalizedRoutingAgentId) return;
+    const matchingAgent = availableAgents.find((agent) => agent.id === nextAgentId);
+    routingAgentId = nextAgentId;
+    routingAgentDisplayName = matchingAgent?.displayName || nextAgentId;
+    await saveSessionRouting();
+  }
+
   function generateChatTitle(input) {
     const trimmed = typeof input === 'string' ? input.trim() : '';
     return trimmed ? trimmed.slice(0, 72) : 'New chat';
@@ -1006,9 +1015,26 @@
         <div>
           <p class="eyebrow">Current chat</p>
           <h2>{selectedSession?.name ?? 'Chat'}</h2>
-          <span class="header-agent-pill" title={`Agent: ${selectedSession?.agentId || 'main'}`}>
-            Agent · {selectedSession?.agentDisplayName || selectedSession?.agentId || 'Primary'}
-          </span>
+          <div class="header-agent-row">
+            <span class="header-agent-pill" title={`Agent: ${selectedSession?.agentId || 'main'}`}>
+              Agent · {selectedSession?.agentDisplayName || selectedSession?.agentId || 'Primary'}
+            </span>
+            <select
+              class="header-agent-select"
+              value={normalizedRoutingAgentId}
+              on:change={quickSwitchHeaderAgent}
+              disabled={routingSaving || !availableAgents.length}
+              aria-label="Switch active agent"
+            >
+              {#if !availableAgents.length}
+                <option value={normalizedRoutingAgentId}>{selectedSession?.agentDisplayName || selectedSession?.agentId || 'Primary'}</option>
+              {:else}
+                {#each availableAgents as agent}
+                  <option value={agent.id}>{agent.displayName || agent.id}</option>
+                {/each}
+              {/if}
+            </select>
+          </div>
         </div>
         <div class="timeline-actions">
           <input

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -269,7 +269,23 @@
     }
 
     const minutes = Math.floor(seconds / 60);
-    gateway = { ...gateway, heartbeat: `${minutes}m ago` };
+    if (minutes < 60) {
+      gateway = { ...gateway, heartbeat: `${minutes}m ago` };
+      return;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+      const remainderMinutes = minutes % 60;
+      gateway = {
+        ...gateway,
+        heartbeat: remainderMinutes ? `${hours}h ${remainderMinutes}m ago` : `${hours}h ago`
+      };
+      return;
+    }
+
+    const days = Math.floor(hours / 24);
+    gateway = { ...gateway, heartbeat: days === 1 ? '1 day ago' : `${days} days ago` };
   }
 
   async function openLogsFolder() {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -831,6 +831,7 @@
 
   $: selectedSession = findSession(selectedSessionId);
   $: syncRoutingDraftFromSession(selectedSession);
+  $: gatewayStatusPill = statusPills[gateway.status] || statusPills.degraded;
   $: normalizedRoutingAgentId = (routingAgentId || '').trim() || 'main';
   $: normalizedRoutingDisplayName = (routingAgentDisplayName || '').trim() || normalizedRoutingAgentId;
   $: routingDirty = Boolean(selectedSession) && (
@@ -862,7 +863,7 @@
         <strong>{gateway.name}</strong>
       </div>
       <div class="gateway-meta">
-        <span class={`pill ${statusPills[gateway.status].tone}`}>{statusPills[gateway.status].label}</span>
+        <span class={`pill ${gatewayStatusPill.tone}`}>{gatewayStatusPill.label}</span>
         <span class="meta">{gateway.endpoint}</span>
         <span class="meta">Last heartbeat · {gateway.heartbeat}</span>
       </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -991,6 +991,7 @@
             on:input={handleSearchInput}
           />
           <button class="ghost" on:click={focusSearchInput}>Jump ⌘K</button>
+          <button class="ghost" on:click={focusComposerInput}>Compose ⌘⇧L</button>
           <button class="ghost" on:click={() => (sideRailOpen = !sideRailOpen)}>
             {sideRailOpen ? 'Hide panel' : 'Show panel'}
           </button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,13 +10,9 @@
     mode: 'Live'
   };
 
-  const contextItems = [
-    { label: 'Channel', value: 'Slack DM' },
-    { label: 'Chat ID', value: 'sess_23ff901' },
-    { label: 'Routing', value: 'Primary agent · tools:on' },
-    { label: 'Safety', value: 'Live · elevated' },
-    { label: 'Last activity', value: '13:05 GMT' }
-  ];
+  let routingAgentId = 'main';
+  let routingAgentDisplayName = 'Primary';
+  let routingSaving = false;
 
   const runs = [
     {
@@ -305,6 +301,7 @@
     persistDraftForSession(selectedSessionId, composerValue);
     selectedSessionId = sessionId;
     selectedSession = findSession(sessionId);
+    syncRoutingDraftFromSession(selectedSession);
     try {
       const client = dataClient ?? fallbackAdapter;
       messages = await client.getMessages(sessionId);
@@ -320,6 +317,43 @@
     searchResults = [];
     highlightedMessageId = null;
     restoreDraftForSession(sessionId);
+  }
+
+  function syncRoutingDraftFromSession(session) {
+    routingAgentId = session?.agentId || 'main';
+    routingAgentDisplayName = session?.agentDisplayName || 'Primary';
+  }
+
+  async function saveSessionRouting() {
+    if (!selectedSessionId || !dataClient?.setSessionAgent || routingSaving) return;
+
+    routingSaving = true;
+    errorMessage = '';
+    try {
+      const updated = await dataClient.setSessionAgent({
+        sessionId: selectedSessionId,
+        agentId: routingAgentId,
+        agentDisplayName: routingAgentDisplayName
+      });
+
+      sections = sections.map((section) => ({
+        ...section,
+        sessions: section.sessions.map((session) => (
+          session.id === selectedSessionId
+            ? {
+              ...session,
+              agentId: updated?.agentId || routingAgentId || 'main',
+              agentDisplayName: updated?.agentDisplayName || routingAgentDisplayName || 'Primary'
+            }
+            : session
+        ))
+      }));
+    } catch (error) {
+      console.error('Unable to save chat routing', error);
+      errorMessage = 'Failed to save chat routing.';
+    } finally {
+      routingSaving = false;
+    }
   }
 
   function generateChatTitle(input) {
@@ -725,11 +759,22 @@
   }
 
   $: selectedSession = findSession(selectedSessionId);
+  $: syncRoutingDraftFromSession(selectedSession);
   $: selectedSessionIsGateway = isGatewaySessionId(selectedSessionId);
   $: sendDisabled = !composerValue.trim() || sendingMessage || (selectedSessionIsGateway && gateway.status === 'offline');
   $: composerGatewayStatus = selectedSessionIsGateway
     ? (gateway.status === 'offline' ? 'Gateway offline' : `Gateway ${gateway.status}`)
     : 'Local chat';
+  $: contextItems = [
+    { label: 'Channel', value: selectedSession?.channel || 'Unknown' },
+    { label: 'Chat ID', value: selectedSession?.id || '—' },
+    {
+      label: 'Routing',
+      value: `${selectedSession?.agentDisplayName || 'Primary'} · ${selectedSession?.agentId || 'main'}`
+    },
+    { label: 'Safety', value: selectedSessionIsGateway ? 'Live · gateway' : 'Local cache' },
+    { label: 'Last activity', value: selectedSession?.lastMessageAt || 'Unknown' }
+  ];
 </script>
 
 <div class="app-frame">
@@ -919,6 +964,21 @@
                 </div>
               {/each}
             </dl>
+            {#if selectedSession}
+              <div class="routing-form">
+                <label>
+                  <span>Agent display name</span>
+                  <input type="text" bind:value={routingAgentDisplayName} placeholder="Primary" />
+                </label>
+                <label>
+                  <span>Agent ID</span>
+                  <input type="text" bind:value={routingAgentId} placeholder="main" />
+                </label>
+                <button class="primary" on:click={saveSessionRouting} disabled={routingSaving}>
+                  {routingSaving ? 'Saving…' : 'Save routing'}
+                </button>
+              </div>
+            {/if}
           {:else if activeRightTab === 'runs'}
             <div class="runs-stack">
               {#each runs as run}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -79,6 +79,7 @@
   let resettingData = false;
   let sendingMessage = false;
   let searchInputEl;
+  let composerInputEl;
   let appMeta = { version: '0.0.0', platform: 'unknown' };
   let preferences = { gatewayUrl: 'http://localhost:4111', theme: 'system' };
   let syncInFlight = false;
@@ -616,6 +617,13 @@
     searchInputEl.select();
   }
 
+  function focusComposerInput() {
+    if (!composerInputEl) return;
+    composerInputEl.focus();
+    const len = composerInputEl.value?.length ?? 0;
+    composerInputEl.setSelectionRange(len, len);
+  }
+
   function selectAdjacentSession(direction = 1) {
     const allSessions = sections.flatMap((section) => section.sessions);
     if (!allSessions.length) return;
@@ -678,6 +686,12 @@
       if (event.shiftKey && event.key.toLowerCase() === 'r') {
         event.preventDefault();
         void hydrateGatewaySessions();
+        return;
+      }
+
+      if (event.shiftKey && event.key.toLowerCase() === 'l') {
+        event.preventDefault();
+        focusComposerInput();
         return;
       }
 
@@ -1055,6 +1069,7 @@
             placeholder="Write a message, /command, or paste logs"
             value={composerValue}
             rows="2"
+            bind:this={composerInputEl}
             on:input={handleComposerInput}
             on:keydown={handleComposerKeydown}
           ></textarea>

--- a/src/app.css
+++ b/src/app.css
@@ -120,25 +120,23 @@ body {
   backdrop-filter: blur(16px);
 }
 
-.gateway {
+.gateway-compact {
   display: flex;
   align-items: center;
-  gap: 1rem;
-}
-
-.gateway strong {
-  font-size: 1.1rem;
-}
-
-.gateway-meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .top-actions {
   display: flex;
   gap: 0.75rem;
+}
+
+.top-actions.compact {
+  gap: 0.45rem;
+}
+
+.top-actions.compact .ghost {
+  padding: 0.28rem 0.62rem;
 }
 
 button {

--- a/src/app.css
+++ b/src/app.css
@@ -190,13 +190,13 @@ button.primary:disabled {
   grid-template-columns: 280px minmax(0, 1fr);
 }
 
-.session-rail {
+.chat-rail {
   border-right: 1px solid rgba(255, 255, 255, 0.05);
   padding: 1rem 1rem 1.5rem;
   overflow-y: auto;
 }
 
-.session-section + .session-section {
+.chat-section + .chat-section {
   margin-top: 1.25rem;
 }
 
@@ -208,7 +208,7 @@ button.primary:disabled {
   text-transform: uppercase;
 }
 
-.session-tile {
+.chat-tile {
   width: 100%;
   background: rgba(255, 255, 255, 0.02);
   border-radius: 14px;
@@ -220,12 +220,12 @@ button.primary:disabled {
   margin-bottom: 0.4rem;
 }
 
-.session-tile.active {
+.chat-tile.active {
   background: linear-gradient(120deg, rgba(122, 123, 255, 0.18), rgba(167, 107, 255, 0.2));
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
 }
 
-.session-tile .tile-main {
+.chat-tile .tile-main {
   display: flex;
   align-items: center;
   gap: 0.6rem;
@@ -547,7 +547,7 @@ button.primary:disabled {
   gap: 0.15rem;
 }
 
-.hit-session,
+.hit-chat,
 .hit-meta {
   font-size: 0.72rem;
   color: #97a0bf;
@@ -644,7 +644,7 @@ button.danger {
 }
 
 @media (max-width: 880px) {
-  .session-rail {
+  .chat-rail {
     display: none;
   }
 

--- a/src/app.css
+++ b/src/app.css
@@ -255,6 +255,13 @@ button.primary:disabled {
   font-size: 0.7rem;
 }
 
+.tile-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+}
+
 .chip {
   font-size: 0.65rem;
   padding: 0.2rem 0.5rem;
@@ -263,6 +270,18 @@ button.primary:disabled {
   letter-spacing: 0.06em;
   background: rgba(255, 255, 255, 0.08);
   color: #9dbafc;
+}
+
+.agent-pill {
+  font-size: 0.62rem;
+  padding: 0.18rem 0.48rem;
+  border-radius: 999px;
+  background: rgba(122, 123, 255, 0.2);
+  color: #cfd7ff;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .status-dot {

--- a/src/app.css
+++ b/src/app.css
@@ -186,8 +186,20 @@ button.primary:disabled {
   overflow: hidden;
 }
 
-.shell-grid.rail-collapsed {
+.shell-grid.side-rail-collapsed {
   grid-template-columns: 280px minmax(0, 1fr);
+}
+
+.shell-grid.chat-rail-collapsed {
+  grid-template-columns: minmax(0, 1fr) 360px;
+}
+
+.shell-grid.chat-rail-collapsed.side-rail-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.shell-grid.chat-rail-collapsed .chat-rail {
+  display: none;
 }
 
 .chat-rail {

--- a/src/app.css
+++ b/src/app.css
@@ -321,6 +321,19 @@ button.primary:disabled {
   font-size: 1.4rem;
 }
 
+.header-agent-pill {
+  display: inline-flex;
+  margin-top: 0.35rem;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #cfd7ff;
+  background: rgba(122, 123, 255, 0.2);
+  border: 1px solid rgba(122, 123, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.15rem 0.52rem;
+}
+
 .timeline-actions {
   display: flex;
   gap: 0.5rem;

--- a/src/app.css
+++ b/src/app.css
@@ -120,10 +120,23 @@ body {
   backdrop-filter: blur(16px);
 }
 
-.gateway-compact {
+.top-bar.compact {
+  border-bottom-color: rgba(255, 255, 255, 0.03);
+}
+
+.gateway-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gateway-details {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 0.45rem 1rem 0.55rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .top-actions {

--- a/src/app.css
+++ b/src/app.css
@@ -115,7 +115,7 @@ body {
 .top-bar {
   display: flex;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
+  padding: 0.6rem 1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(16px);
 }
@@ -204,12 +204,67 @@ button.primary:disabled {
 
 .chat-rail {
   border-right: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 1rem 1rem 1.5rem;
+  padding: 0.9rem 0.9rem 1rem;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.chat-rail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rail-collapse {
+  padding: 0.25rem 0.6rem !important;
+}
+
+.new-chat {
+  width: 100%;
+}
+
+.left-nav {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.4rem;
+}
+
+.left-nav button {
+  background: rgba(255, 255, 255, 0.04);
+  color: #cad3f6;
+  border-radius: 8px;
+  padding: 0.42rem 0.5rem;
+}
+
+.left-nav button.active {
+  background: rgba(122, 123, 255, 0.26);
+  color: #eef1ff;
+}
+
+.agent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.agent-row {
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
 }
 
 .chat-section + .chat-section {
-  margin-top: 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.chat-rail-footer {
+  margin-top: auto;
+  padding-top: 0.6rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .section-label {
@@ -224,12 +279,15 @@ button.primary:disabled {
   width: 100%;
   background: rgba(255, 255, 255, 0.02);
   border-radius: 14px;
-  padding: 0.75rem;
+  padding: 0.65rem;
   color: inherit;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 0.4rem;
+  position: relative;
+  text-align: left;
+  cursor: pointer;
 }
 
 .chat-tile.active {
@@ -239,8 +297,9 @@ button.primary:disabled {
 
 .chat-tile .tile-main {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.6rem;
+  flex: 1;
 }
 
 .name-row {
@@ -257,6 +316,10 @@ button.primary:disabled {
   margin: 0.15rem 0 0;
   font-size: 0.8rem;
   color: #9ca7ce;
+}
+
+.tile-time {
+  margin-top: 0.15rem;
 }
 
 .badge {
@@ -294,6 +357,38 @@ button.primary:disabled {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tile-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: 0.4rem;
+  position: relative;
+}
+
+.overflow {
+  padding: 0.1rem 0.45rem !important;
+  border-radius: 8px !important;
+}
+
+.chat-menu {
+  position: absolute;
+  top: 1.5rem;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: #0e1220;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.35rem;
+  z-index: 3;
+}
+
+.chat-menu .ghost {
+  white-space: nowrap;
+  text-align: left;
 }
 
 .status-dot {

--- a/src/app.css
+++ b/src/app.css
@@ -333,9 +333,15 @@ button.primary:disabled {
   font-size: 1.4rem;
 }
 
+.header-agent-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+}
+
 .header-agent-pill {
   display: inline-flex;
-  margin-top: 0.35rem;
   font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -344,6 +350,20 @@ button.primary:disabled {
   border: 1px solid rgba(122, 123, 255, 0.35);
   border-radius: 999px;
   padding: 0.15rem 0.52rem;
+}
+
+.header-agent-select {
+  min-width: 128px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 123, 255, 0.45);
+  background: rgba(21, 24, 40, 0.9);
+  color: #d9dfff;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.74rem;
+}
+
+.header-agent-select:disabled {
+  opacity: 0.6;
 }
 
 .timeline-actions {

--- a/src/app.css
+++ b/src/app.css
@@ -464,6 +464,34 @@ button.primary:disabled {
   font-weight: 600;
 }
 
+.routing-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding-top: 0.25rem;
+}
+
+.routing-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: #9ba6cd;
+}
+
+.routing-form input {
+  width: 100%;
+  background: rgba(14, 16, 28, 0.95);
+  color: #f0f3ff;
+  border: 1px solid rgba(120, 134, 184, 0.55);
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
+}
+
+.routing-form button {
+  align-self: flex-start;
+}
+
 .runs-stack {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- rename user-facing desktop UI copy from **Sessions** to **Chats** where it refers to conversation threads
- auto-generate chat titles from the first user message in `ChatDatabase.addMessage`
- keep generated titles stable after initial set (no silent retitle)
- cap generated titles at 72 chars, with fallback to `New chat`
- add tests for title generation, truncation, and no-retitle behavior

## Issues
Closes #8
Closes #9

## Validation
- `npm test` ✅ (core suite passes; DB-native tests are runtime-skipped when local `better-sqlite3` ABI differs)
- `npm run build` ✅

## Notes
- Internal API/runtime naming (`sessionId`, table names, IPC channel names) remains unchanged, per issue scope.
