### PR TITLE
Chat-first sidebar + conversation-focused default layout

### DIFF
--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -37,6 +37,8 @@ class ChatDatabase {
         unread INTEGER NOT NULL DEFAULT 0,
         chip TEXT NOT NULL,
         status TEXT NOT NULL,
+        agent_id TEXT NOT NULL DEFAULT 'main',
+        agent_display_name TEXT NOT NULL DEFAULT 'Main',
         created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
         FOREIGN KEY(group_id) REFERENCES sections(id) ON DELETE CASCADE
       );
@@ -89,6 +91,14 @@ class ChatDatabase {
         WHERE rowid = new.id;
       END;
     `);
+
+    try {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'main'");
+    } catch {}
+
+    try {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_display_name TEXT NOT NULL DEFAULT 'Main'");
+    } catch {}
   }
 
   #seedIfNeeded() {
@@ -102,8 +112,8 @@ class ChatDatabase {
       'INSERT INTO sections (id, title, position) VALUES (@id, @title, @position)'
     );
     const insertSession = this.db.prepare(`
-      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
-      VALUES (@id, @groupId, @name, @channel, @preview, @unread, @chip, @status)
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status, agent_id, agent_display_name)
+      VALUES (@id, @groupId, @name, @channel, @preview, @unread, @chip, @status, @agentId, @agentDisplayName)
     `);
     const insertMessage = this.db.prepare(`
       INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp, meta_pill, meta_detail, reactions)
@@ -112,7 +122,11 @@ class ChatDatabase {
 
     const transaction = this.db.transaction(() => {
       seed.sections.forEach((section) => insertSection.run(section));
-      seed.sessions.forEach((session) => insertSession.run(session));
+      seed.sessions.forEach((session) => insertSession.run({
+        agentId: 'main',
+        agentDisplayName: 'Main',
+        ...session
+      }));
       seed.messages.forEach((message) => insertMessage.run({
         meta_pill: null,
         meta_detail: null,
@@ -130,7 +144,8 @@ class ChatDatabase {
       .all();
     const sessions = this.db
       .prepare(`
-        SELECT id, group_id as groupId, name, channel, preview, unread, chip, status
+        SELECT id, group_id as groupId, name, channel, preview, unread, chip, status,
+               agent_id as agentId, agent_display_name as agentDisplayName
         FROM sessions
         ORDER BY created_at DESC
       `)
@@ -226,7 +241,7 @@ class ChatDatabase {
       }));
   }
 
-  addMessage({ sessionId, content, author = 'Operator', role = 'user' }) {
+  addMessage({ sessionId, content, author = 'Operator', role = 'user', metaPill = null, metaDetail = null }) {
     const trimmed = typeof content === 'string' ? content.trim() : '';
     if (!sessionId || !trimmed) {
       throw new Error('sessionId and content are required');
@@ -237,23 +252,31 @@ class ChatDatabase {
       throw new Error('Session not found');
     }
 
+    const firstUserMessage = role === 'user'
+      ? this.db.prepare("SELECT COUNT(*) as count FROM messages WHERE session_id = ? AND role = 'user'").get(sessionId).count === 0
+      : false;
+
     const messageKey = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const timestamp = this.#formatDisplayTimestamp(new Date());
 
     const result = this.db
       .prepare(`
-        INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp, meta_pill, meta_detail)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `)
-      .run(sessionId, messageKey, role, author, trimmed, timestamp);
+      .run(sessionId, messageKey, role, author, trimmed, timestamp, metaPill, metaDetail);
+
+    const nextTitle = firstUserMessage ? this.#deriveChatTitle(trimmed) : null;
 
     this.db
       .prepare(`
         UPDATE sessions
-        SET preview = ?, created_at = strftime('%s','now')
+        SET preview = ?,
+            name = COALESCE(?, name),
+            created_at = strftime('%s','now')
         WHERE id = ?
       `)
-      .run(trimmed.slice(0, 160), sessionId);
+      .run(trimmed.slice(0, 160), nextTitle, sessionId);
 
     const row = this.db
       .prepare(`
@@ -274,6 +297,57 @@ class ChatDatabase {
       ...row,
       reactions: row.reactions ? row.reactions.split(',').map((item) => item.trim()).filter(Boolean) : undefined,
       meta: row.metaPill ? { pill: row.metaPill, detail: row.metaDetail || '' } : undefined
+    };
+  }
+
+  getSessionById(sessionId) {
+    if (!sessionId) return null;
+
+    return this.db.prepare(`
+      SELECT id,
+             group_id as groupId,
+             name,
+             channel,
+             preview,
+             unread,
+             chip,
+             status,
+             agent_id as agentId,
+             agent_display_name as agentDisplayName
+      FROM sessions
+      WHERE id = ?
+    `).get(sessionId) || null;
+  }
+
+  setSessionAgent(sessionId, { agentId, agentDisplayName }) {
+    if (!sessionId || !agentId || !agentDisplayName) {
+      throw new Error('sessionId, agentId and agentDisplayName are required');
+    }
+
+    const result = this.db.prepare(`
+      UPDATE sessions
+      SET agent_id = ?,
+          agent_display_name = ?,
+          created_at = strftime('%s','now')
+      WHERE id = ?
+    `).run(agentId, agentDisplayName, sessionId);
+
+    if (!result.changes) {
+      throw new Error('Session not found');
+    }
+
+    const systemMessage = this.addMessage({
+      sessionId,
+      role: 'system',
+      author: 'System',
+      content: `Switched to ${agentDisplayName}`,
+      metaPill: 'switch',
+      metaDetail: agentDisplayName
+    });
+
+    return {
+      session: this.getSessionById(sessionId),
+      systemMessage
     };
   }
 
@@ -430,6 +504,21 @@ class ChatDatabase {
     });
 
     tx();
+  }
+
+  #deriveChatTitle(content) {
+    const cleaned = String(content || '')
+      .replace(/`{1,3}[^`]*`{1,3}/g, ' ')
+      .replace(/\*\*|__|~~|`|#+|>+/g, ' ')
+      .replace(/\[[^\]]*\]\([^\)]*\)/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    if (!cleaned) {
+      return 'New chat';
+    }
+
+    return cleaned.slice(0, 72);
   }
 
   #formatDisplayTimestamp(date) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -88,6 +88,10 @@ ipcMain.handle('data:reset', () => {
   return database.resetData();
 });
 
+ipcMain.handle('data:set-session-agent', (_event, payload) => {
+  return database.setSessionAgent(payload?.sessionId, payload || {});
+});
+
 ipcMain.handle('data:sync-gateway-sessions', async () => {
   try {
     const { stdout } = await execFileAsync('openclaw', ['sessions', '--json'], { maxBuffer: 2 * 1024 * 1024 });
@@ -101,13 +105,14 @@ ipcMain.handle('data:sync-gateway-sessions', async () => {
 
 ipcMain.handle('data:send-message', async (_event, payload) => {
   const userMessage = database.addMessage(payload);
+  const session = database.getSessionById(payload?.sessionId);
 
   const looksLikeGatewaySession = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(payload?.sessionId || '');
 
   try {
     const args = looksLikeGatewaySession
       ? ['agent', '--session-id', payload.sessionId, '--message', payload.content, '--json']
-      : ['agent', '--agent', 'main', '--message', payload.content, '--json'];
+      : ['agent', '--agent', session?.agentId || 'main', '--message', payload.content, '--json'];
 
     const { stdout } = await execFileAsync(
       'openclaw',
@@ -123,7 +128,7 @@ ipcMain.handle('data:send-message', async (_event, payload) => {
       author: 'OpenClaw'
     });
 
-    return { userMessage, assistantMessage };
+    return { userMessage, assistantMessage, session: database.getSessionById(payload?.sessionId) };
   } catch (error) {
     const assistantMessage = database.addMessage({
       sessionId: payload.sessionId,
@@ -132,7 +137,7 @@ ipcMain.handle('data:send-message', async (_event, payload) => {
       author: 'System'
     });
 
-    return { userMessage, assistantMessage };
+    return { userMessage, assistantMessage, session: database.getSessionById(payload?.sessionId) };
   }
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('chatDesktop', {
     setComposerDrafts: (drafts) => ipcRenderer.invoke('data:set-composer-drafts', drafts),
     reset: () => ipcRenderer.invoke('data:reset'),
     syncGatewaySessions: () => ipcRenderer.invoke('data:sync-gateway-sessions'),
+    setSessionAgent: (payload) => ipcRenderer.invoke('data:set-session-agent', payload),
     sendMessage: (payload) => ipcRenderer.invoke('data:send-message', payload)
   }
 });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -57,6 +57,12 @@
     degraded: { label: 'Degraded', tone: 'warning' }
   };
 
+  const agentOptions = [
+    { id: 'main', displayName: 'Main' },
+    { id: 'coder', displayName: 'Coder' },
+    { id: 'planner', displayName: 'Planner' }
+  ];
+
   let sections = buildSectionsFromSeed();
   let selectedSessionId = sections[0]?.sessions[0]?.id ?? null;
   let messages = buildMessagesFromSeed(selectedSessionId);
@@ -75,7 +81,10 @@
   let highlightTimeout;
   let draftPersistTimer;
   let showSettings = false;
-  let sideRailOpen = true;
+  let sideRailOpen = false;
+  let leftRailOpen = true;
+  let leftRailNav = 'chats';
+  let chatMenuOpenFor = null;
   let settingsSaving = false;
   let resettingData = false;
   let sendingMessage = false;
@@ -297,6 +306,8 @@
       return;
     }
 
+    chatMenuOpenFor = null;
+
     persistDraftForSession(selectedSessionId, composerValue);
     selectedSessionId = sessionId;
     selectedSession = findSession(sessionId);
@@ -315,14 +326,47 @@
     restoreDraftForSession(sessionId);
   }
 
-  function updateSessionPreview(sessionId, preview) {
+  function createNewChat() {
+    const sessionId = `local-${Date.now()}`;
+    const freshSession = {
+      id: sessionId,
+      name: 'New chat',
+      channel: 'Local',
+      preview: 'Start the conversation…',
+      unread: 0,
+      chip: 'local',
+      status: 'idle'
+    };
+
+    sections = sections.map((section, index) => {
+      if (index !== 0) return section;
+      return { ...section, sessions: [freshSession, ...section.sessions] };
+    });
+
+    void selectSession(sessionId);
+  }
+
+  function toggleChatMenu(event, sessionId) {
+    event.stopPropagation();
+    chatMenuOpenFor = chatMenuOpenFor === sessionId ? null : sessionId;
+  }
+
+  function handleChatMenuAction(event, sessionId) {
+    event.stopPropagation();
+    chatMenuOpenFor = null;
+    if (sessionId) {
+      errorMessage = `Chat actions are coming soon (${sessionId.slice(0, 8)}…).`;
+    }
+  }
+
+  function applySessionPatch(sessionId, patch = {}) {
     sections = sections.map((section) => {
       const hasSession = section.sessions.some((session) => session.id === sessionId);
       if (!hasSession) return section;
 
       const nextSessions = section.sessions.map((session) => (
         session.id === sessionId
-          ? { ...session, preview: preview.slice(0, 160) }
+          ? { ...session, ...patch }
           : session
       ));
 
@@ -356,7 +400,11 @@
       messages = incoming ? [...messages, outgoing, incoming] : [...messages, outgoing];
       composerValue = '';
       persistDraftForSession(selectedSessionId, '');
-      updateSessionPreview(selectedSessionId, incoming?.content || content);
+      if (delivery?.session) {
+        applySessionPatch(selectedSessionId, delivery.session);
+      } else {
+        applySessionPatch(selectedSessionId, { preview: (incoming?.content || content).slice(0, 160) });
+      }
       await tick();
       highlightMessage((incoming || outgoing)?.id);
     } catch (error) {
@@ -364,6 +412,33 @@
       errorMessage = 'Unable to send message right now.';
     } finally {
       sendingMessage = false;
+    }
+  }
+
+  async function handleAgentChange(event) {
+    const nextAgentId = event.currentTarget.value;
+    const nextAgent = agentOptions.find((item) => item.id === nextAgentId) ?? agentOptions[0];
+    if (!selectedSessionId || !nextAgent || selectedSession?.agentId === nextAgent.id) return;
+
+    try {
+      const client = dataClient ?? fallbackAdapter;
+      const result = await client.setSessionAgent({
+        sessionId: selectedSessionId,
+        agentId: nextAgent.id,
+        agentDisplayName: nextAgent.displayName
+      });
+
+      if (result?.session) {
+        applySessionPatch(selectedSessionId, result.session);
+      }
+      if (result?.systemMessage) {
+        messages = [...messages, result.systemMessage];
+        await tick();
+        highlightMessage(result.systemMessage.id);
+      }
+    } catch (error) {
+      console.error('Unable to switch agent', error);
+      errorMessage = 'Failed to switch agent for this chat.';
     }
   }
 
@@ -468,6 +543,12 @@
         return;
       }
 
+      if (event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        leftRailOpen = !leftRailOpen;
+        return;
+      }
+
       if (event.shiftKey && event.key === '[') {
         event.preventDefault();
         selectAdjacentSession(-1);
@@ -545,12 +626,46 @@
         timeZone: 'Europe/London'
       }).format(now);
 
+      const session = findSession(payload.sessionId);
+      const isFirstUserMessage = !messages.some((message) => message.role === 'user');
+
       return {
         id: `local-${now.getTime()}`,
         role: payload.role ?? 'user',
         author: payload.author ?? 'Operator',
         timestamp,
-        content: payload.content
+        content: payload.content,
+        session: {
+          ...session,
+          preview: payload.content.slice(0, 160),
+          name: isFirstUserMessage ? deriveChatTitle(payload.content) : session?.name
+        }
+      };
+    },
+    async setSessionAgent(payload) {
+      const now = new Date();
+      const session = findSession(payload.sessionId);
+      const timestamp = new Intl.DateTimeFormat('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'Europe/London'
+      }).format(now);
+
+      return {
+        session: {
+          ...session,
+          agentId: payload.agentId,
+          agentDisplayName: payload.agentDisplayName
+        },
+        systemMessage: {
+          id: `local-switch-${now.getTime()}`,
+          role: 'system',
+          author: 'System',
+          timestamp,
+          content: `Switched to ${payload.agentDisplayName}`,
+          meta: { pill: 'switch', detail: payload.agentDisplayName }
+        }
       };
     },
     async searchMessages(query) {
@@ -573,6 +688,15 @@
         });
     }
   };
+
+  function deriveChatTitle(text) {
+    const cleaned = (text || '')
+      .replace(/[`*_#>\[\]()]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!cleaned) return 'New chat';
+    return cleaned.slice(0, 72);
+  }
 
   function escapeHtml(text) {
     return text.replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char] || char));
@@ -664,54 +788,79 @@
 </script>
 
 <div class="app-frame">
-  <header class="top-bar">
-    <div class="gateway">
-      <div>
-        <p class="eyebrow">Gateway</p>
-        <strong>{gateway.name}</strong>
-      </div>
-      <div class="gateway-meta">
-        <span class={`pill ${statusPills[gateway.status].tone}`}>{statusPills[gateway.status].label}</span>
-        <span class="meta">{gateway.endpoint}</span>
-        <span class="meta">Last heartbeat · {gateway.heartbeat}</span>
-      </div>
+  <header class="top-bar compact">
+    <div class="gateway-meta">
+      <span class={`pill ${statusPills[gateway.status].tone}`}>{statusPills[gateway.status].label}</span>
+      <span class="meta">{gateway.name}</span>
+      <span class="meta">{gateway.heartbeat}</span>
     </div>
     <div class="top-actions">
-      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
-      <button class="ghost" on:click={openLogsFolder}>Open logs</button>
-      <button class="primary" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
-        {syncInFlight ? 'Syncing…' : 'Sync chats'}
+      <button class="ghost" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
+        {syncInFlight ? 'Syncing…' : 'Sync'}
       </button>
+      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
     </div>
   </header>
 
-  <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'}`}>
+  <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'} ${leftRailOpen ? '' : 'left-collapsed'}`}>
     <aside class="session-rail" aria-label="Chat list">
-      {#each sections as section}
-        <div class="session-section">
-          <p class="section-label">{section.title}</p>
-          {#each section.sessions as session}
-            <button
-              class={`session-tile ${session.id === selectedSessionId ? 'active' : ''}`}
-              on:click={() => selectSession(session.id)}
-            >
-              <div class="tile-main">
-                <div>
-                  <div class="name-row">
-                    <span class="name">{session.name}</span>
-                    {#if session.unread}
-                      <span class="badge">{session.unread}</span>
-                    {/if}
+      <div class="rail-header">
+        <strong>OpenClaw Chat</strong>
+        <button class="ghost icon" on:click={() => (leftRailOpen = false)} title="Collapse sidebar">⟨</button>
+      </div>
+      <button class="primary new-chat" on:click={createNewChat}>+ New chat</button>
+      <nav class="rail-nav" aria-label="Primary navigation">
+        <button class={leftRailNav === 'chats' ? 'active' : ''} on:click={() => (leftRailNav = 'chats')}>Chats</button>
+        <button class={leftRailNav === 'agents' ? 'active' : ''} on:click={() => (leftRailNav = 'agents')}>Agents</button>
+      </nav>
+
+      {#if leftRailNav === 'chats'}
+        {#each sections as section}
+          <div class="session-section">
+            <p class="section-label">{section.title}</p>
+            {#each section.sessions as session}
+              <div
+                class={`session-tile ${session.id === selectedSessionId ? 'active' : ''}`}
+                role="button"
+                tabindex="0"
+                on:click={() => selectSession(session.id)}
+                on:keydown={(event) => event.key === 'Enter' && selectSession(session.id)}
+              >
+                <div class="tile-main">
+                  <div>
+                    <div class="name-row">
+                      <span class="name">{session.name}</span>
+                      <span class="agent-badge" title={`Active agent: ${session.agentDisplayName ?? 'Main'}`}>
+                        {session.agentDisplayName ?? 'Main'}
+                      </span>
+                      {#if session.unread}
+                        <span class="badge">{session.unread}</span>
+                      {/if}
+                    </div>
+                    <p class="preview">{session.channel} · {session.preview}</p>
                   </div>
-                  <p class="preview">{session.preview}</p>
                 </div>
-                <span class={`chip ${session.chip}`}>{session.channel}</span>
+                <div class="tile-actions">
+                  <button class="ghost icon" on:click={(event) => toggleChatMenu(event, session.id)} aria-label="Chat actions">⋯</button>
+                  {#if chatMenuOpenFor === session.id}
+                    <div class="chat-menu">
+                      <button on:click={(event) => handleChatMenuAction(event, session.id)}>Copy chat ID</button>
+                      <button on:click={(event) => handleChatMenuAction(event, session.id)}>Mute chat</button>
+                    </div>
+                  {/if}
+                </div>
               </div>
-              <span class={`status-dot ${session.status}`}></span>
-            </button>
-          {/each}
-        </div>
-      {/each}
+            {/each}
+          </div>
+        {/each}
+      {:else}
+        <div class="agents-placeholder meta">Agent management stays available here.</div>
+      {/if}
+
+      <footer class="rail-footer">
+        <button class="ghost" on:click={openLogsFolder}>Open logs</button>
+        <button class="ghost" on:click={() => (showSettings = true)}>Profile & settings</button>
+      </footer>
     </aside>
 
     <section class="timeline-area" aria-label="Conversation timeline">
@@ -719,8 +868,19 @@
         <div>
           <p class="eyebrow">Current chat</p>
           <h2>{selectedSession?.name ?? 'Chat'}</h2>
+          <label class="agent-switcher">
+            <span>Agent</span>
+            <select value={selectedSession?.agentId ?? 'main'} on:change={handleAgentChange}>
+              {#each agentOptions as agent}
+                <option value={agent.id}>{agent.displayName}</option>
+              {/each}
+            </select>
+          </label>
         </div>
         <div class="timeline-actions">
+          {#if !leftRailOpen}
+            <button class="ghost" on:click={() => (leftRailOpen = true)}>Show chats</button>
+          {/if}
           <input
             class="search-input"
             type="search"
@@ -730,9 +890,9 @@
             bind:this={searchInputEl}
             on:input={handleSearchInput}
           />
-          <button class="ghost" on:click={focusSearchInput}>Jump ⌘K</button>
+          <button class="ghost" on:click={focusSearchInput}>⌘K</button>
           <button class="ghost" on:click={() => (sideRailOpen = !sideRailOpen)}>
-            {sideRailOpen ? 'Hide panel' : 'Show panel'}
+            {sideRailOpen ? 'Hide details' : 'Show details'}
           </button>
         </div>
       </header>
@@ -773,7 +933,7 @@
       {#if loading}
         <div class="loading-state">Loading conversation…</div>
       {:else if !messages.length}
-        <div class="empty-state">No messages in this session yet.</div>
+        <div class="empty-state">No messages in this chat yet.</div>
       {:else}
         <div class="message-list">
           {#each messages as message}
@@ -822,6 +982,7 @@
         </div>
         <div class="composer-meta">
           <span class="meta">Send as · Operator</span>
+          <span class="meta">Agent · {selectedSession?.agentDisplayName ?? 'Main'}</span>
           <span class="meta">{composerGatewayStatus}</span>
         </div>
       </footer>

--- a/src/app.css
+++ b/src/app.css
@@ -120,14 +120,8 @@ body {
   backdrop-filter: blur(16px);
 }
 
-.gateway {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.gateway strong {
-  font-size: 1.1rem;
+.top-bar.compact {
+  padding: 0.6rem 1rem;
 }
 
 .gateway-meta {
@@ -181,27 +175,71 @@ button.primary:disabled {
 
 .shell-grid {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr) 360px;
+  grid-template-columns: 300px minmax(0, 1fr) 320px;
   flex: 1;
   overflow: hidden;
 }
 
 .shell-grid.rail-collapsed {
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: 300px minmax(0, 1fr);
+}
+
+.shell-grid.left-collapsed {
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+.shell-grid.left-collapsed.rail-collapsed {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .session-rail {
   border-right: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 1rem 1rem 1.5rem;
+  padding: 0.9rem;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.rail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+button.icon {
+  min-width: 32px;
+  padding: 0.35rem;
+}
+
+.new-chat {
+  width: 100%;
+}
+
+.rail-nav {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.4rem;
+}
+
+.rail-nav button {
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #b7c1e5;
+  padding: 0.45rem;
+}
+
+.rail-nav button.active {
+  background: rgba(122, 123, 255, 0.2);
+  color: #fff;
 }
 
 .session-section + .session-section {
-  margin-top: 1.25rem;
+  margin-top: 0.8rem;
 }
 
 .section-label {
-  margin: 0 0 0.3rem;
+  margin: 0 0 0.35rem;
   font-size: 0.75rem;
   color: #7c85a2;
   letter-spacing: 0.08em;
@@ -211,24 +249,18 @@ button.primary:disabled {
 .session-tile {
   width: 100%;
   background: rgba(255, 255, 255, 0.02);
-  border-radius: 14px;
-  padding: 0.75rem;
+  border-radius: 12px;
+  padding: 0.65rem;
   color: inherit;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.35rem;
+  position: relative;
 }
 
 .session-tile.active {
   background: linear-gradient(120deg, rgba(122, 123, 255, 0.18), rgba(167, 107, 255, 0.2));
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
-}
-
-.session-tile .tile-main {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
 }
 
 .name-row {
@@ -237,14 +269,21 @@ button.primary:disabled {
   gap: 0.4rem;
 }
 
-.name {
-  font-weight: 600;
+.name { font-weight: 600; }
+
+.agent-badge {
+  font-size: 0.64rem;
+  padding: 0.12rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(157, 186, 252, 0.18);
+  color: #cfe0ff;
 }
 
 .preview {
-  margin: 0.15rem 0 0;
-  font-size: 0.8rem;
+  margin: 0.1rem 0 0;
+  font-size: 0.76rem;
   color: #9ca7ce;
+  text-align: left;
 }
 
 .badge {
@@ -255,30 +294,37 @@ button.primary:disabled {
   font-size: 0.7rem;
 }
 
-.chip {
-  font-size: 0.65rem;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  background: rgba(255, 255, 255, 0.08);
-  color: #9dbafc;
+.tile-actions { position: relative; }
+
+.chat-menu {
+  position: absolute;
+  right: 0;
+  top: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  background: #141a2b;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  min-width: 130px;
+  z-index: 2;
 }
 
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #3d4a65;
+.chat-menu button {
+  background: transparent;
+  color: #d9e1ff;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
 }
 
-.status-dot.live {
-  background: #6dffb0;
-  box-shadow: 0 0 8px #6dffb0;
+.rail-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
-.status-dot.muted {
-  background: #484b5f;
+.agents-placeholder {
+  padding: 0.6rem;
 }
 
 .timeline-area {


### PR DESCRIPTION
## Summary
Implements the UI updates requested in #10 and #12 with a minimal-risk, chat-first refresh.

### #10 Left pane redesign
- Added DeerFlow-style sidebar structure: app header, collapse control, "New chat", Chats/Agents nav, recent chat sections, and footer actions
- Updated recent chat rows to show title + secondary metadata (`channel · preview`)
- Added per-chat overflow menu affordance (⋯) with actions scaffolded for follow-up wiring

### #12 Conversation-focused layout polish
- Right details rail is now hidden by default in chat mode
- Reduced top bar visual dominance while keeping gateway status + sync available
- Kept main timeline/composer central, and retained keyboard shortcuts (plus Cmd/Ctrl+B to toggle chat rail)

### Data/interaction support
- New local chat creation from sidebar
- Chat title derivation from first user message (fallback: "New chat", max 72 chars)
- Per-chat agent metadata wiring + agent badge visibility

## Validation
- `npm test` ✅ (passes; 3 sqlite-dependent tests are skipped due local native module/runtime mismatch in Node test runner)
- `npm run build` ✅ (renderer + electron packaging complete)

## Before / After notes
- **Before:** Sessions-first rail, dominant top bar, right rail visible by default
- **After:** Chat-first sidebar hierarchy, compact top bar, details rail on-demand, conversation flow visually primary

Closes #10
Closes #12
