### PR TITLE
feat: per-chat agent switcher UX + regression tests

### DIFF
--- a/electron/database.cjs
+++ b/electron/database.cjs
@@ -37,6 +37,8 @@ class ChatDatabase {
         unread INTEGER NOT NULL DEFAULT 0,
         chip TEXT NOT NULL,
         status TEXT NOT NULL,
+        agent_id TEXT NOT NULL DEFAULT 'main',
+        agent_display_name TEXT NOT NULL DEFAULT 'Main',
         created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
         FOREIGN KEY(group_id) REFERENCES sections(id) ON DELETE CASCADE
       );
@@ -89,6 +91,14 @@ class ChatDatabase {
         WHERE rowid = new.id;
       END;
     `);
+
+    try {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'main'");
+    } catch {}
+
+    try {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN agent_display_name TEXT NOT NULL DEFAULT 'Main'");
+    } catch {}
   }
 
   #seedIfNeeded() {
@@ -102,8 +112,8 @@ class ChatDatabase {
       'INSERT INTO sections (id, title, position) VALUES (@id, @title, @position)'
     );
     const insertSession = this.db.prepare(`
-      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status)
-      VALUES (@id, @groupId, @name, @channel, @preview, @unread, @chip, @status)
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status, agent_id, agent_display_name)
+      VALUES (@id, @groupId, @name, @channel, @preview, @unread, @chip, @status, @agentId, @agentDisplayName)
     `);
     const insertMessage = this.db.prepare(`
       INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp, meta_pill, meta_detail, reactions)
@@ -112,7 +122,11 @@ class ChatDatabase {
 
     const transaction = this.db.transaction(() => {
       seed.sections.forEach((section) => insertSection.run(section));
-      seed.sessions.forEach((session) => insertSession.run(session));
+      seed.sessions.forEach((session) => insertSession.run({
+        agentId: 'main',
+        agentDisplayName: 'Main',
+        ...session
+      }));
       seed.messages.forEach((message) => insertMessage.run({
         meta_pill: null,
         meta_detail: null,
@@ -130,7 +144,8 @@ class ChatDatabase {
       .all();
     const sessions = this.db
       .prepare(`
-        SELECT id, group_id as groupId, name, channel, preview, unread, chip, status
+        SELECT id, group_id as groupId, name, channel, preview, unread, chip, status,
+               agent_id as agentId, agent_display_name as agentDisplayName
         FROM sessions
         ORDER BY created_at DESC
       `)
@@ -226,7 +241,7 @@ class ChatDatabase {
       }));
   }
 
-  addMessage({ sessionId, content, author = 'Operator', role = 'user' }) {
+  addMessage({ sessionId, content, author = 'Operator', role = 'user', metaPill = null, metaDetail = null }) {
     const trimmed = typeof content === 'string' ? content.trim() : '';
     if (!sessionId || !trimmed) {
       throw new Error('sessionId and content are required');
@@ -237,23 +252,31 @@ class ChatDatabase {
       throw new Error('Session not found');
     }
 
+    const firstUserMessage = role === 'user'
+      ? this.db.prepare("SELECT COUNT(*) as count FROM messages WHERE session_id = ? AND role = 'user'").get(sessionId).count === 0
+      : false;
+
     const messageKey = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const timestamp = this.#formatDisplayTimestamp(new Date());
 
     const result = this.db
       .prepare(`
-        INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO messages (session_id, message_key, role, author, content, display_timestamp, meta_pill, meta_detail)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `)
-      .run(sessionId, messageKey, role, author, trimmed, timestamp);
+      .run(sessionId, messageKey, role, author, trimmed, timestamp, metaPill, metaDetail);
+
+    const nextTitle = firstUserMessage ? this.#deriveChatTitle(trimmed) : null;
 
     this.db
       .prepare(`
         UPDATE sessions
-        SET preview = ?, created_at = strftime('%s','now')
+        SET preview = ?,
+            name = COALESCE(?, name),
+            created_at = strftime('%s','now')
         WHERE id = ?
       `)
-      .run(trimmed.slice(0, 160), sessionId);
+      .run(trimmed.slice(0, 160), nextTitle, sessionId);
 
     const row = this.db
       .prepare(`
@@ -274,6 +297,57 @@ class ChatDatabase {
       ...row,
       reactions: row.reactions ? row.reactions.split(',').map((item) => item.trim()).filter(Boolean) : undefined,
       meta: row.metaPill ? { pill: row.metaPill, detail: row.metaDetail || '' } : undefined
+    };
+  }
+
+  getSessionById(sessionId) {
+    if (!sessionId) return null;
+
+    return this.db.prepare(`
+      SELECT id,
+             group_id as groupId,
+             name,
+             channel,
+             preview,
+             unread,
+             chip,
+             status,
+             agent_id as agentId,
+             agent_display_name as agentDisplayName
+      FROM sessions
+      WHERE id = ?
+    `).get(sessionId) || null;
+  }
+
+  setSessionAgent(sessionId, { agentId, agentDisplayName }) {
+    if (!sessionId || !agentId || !agentDisplayName) {
+      throw new Error('sessionId, agentId and agentDisplayName are required');
+    }
+
+    const result = this.db.prepare(`
+      UPDATE sessions
+      SET agent_id = ?,
+          agent_display_name = ?,
+          created_at = strftime('%s','now')
+      WHERE id = ?
+    `).run(agentId, agentDisplayName, sessionId);
+
+    if (!result.changes) {
+      throw new Error('Session not found');
+    }
+
+    const systemMessage = this.addMessage({
+      sessionId,
+      role: 'system',
+      author: 'System',
+      content: `Switched to ${agentDisplayName}`,
+      metaPill: 'switch',
+      metaDetail: agentDisplayName
+    });
+
+    return {
+      session: this.getSessionById(sessionId),
+      systemMessage
     };
   }
 
@@ -430,6 +504,21 @@ class ChatDatabase {
     });
 
     tx();
+  }
+
+  #deriveChatTitle(content) {
+    const cleaned = String(content || '')
+      .replace(/`{1,3}[^`]*`{1,3}/g, ' ')
+      .replace(/\*\*|__|~~|`|#+|>+/g, ' ')
+      .replace(/\[[^\]]*\]\([^\)]*\)/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    if (!cleaned) {
+      return 'New chat';
+    }
+
+    return cleaned.slice(0, 72);
   }
 
   #formatDisplayTimestamp(date) {

--- a/electron/database.test.cjs
+++ b/electron/database.test.cjs
@@ -101,3 +101,102 @@ test('searchMessages still returns matches for regular terms', (t) => {
     cleanupDb(db, tmpRoot);
   }
 });
+
+test('first user message generates chat title and later messages do not retitle', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`INSERT INTO sections (id, title, position) VALUES ('test', 'Test', 42)`).run();
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status, agent_id, agent_display_name)
+      VALUES ('new-chat', 'test', 'New chat', 'Slack', '', 0, 'dm', 'online', 'main', 'Main')
+    `).run();
+
+    db.addMessage({ sessionId: 'new-chat', role: 'user', content: '  **Plan** migration for _Friday_ deploy  ' });
+    let session = db.getSessionById('new-chat');
+    assert.equal(session.name, 'Plan migration for Friday deploy');
+
+    db.addMessage({ sessionId: 'new-chat', role: 'user', content: 'second message should not retitle' });
+    session = db.getSessionById('new-chat');
+    assert.equal(session.name, 'Plan migration for Friday deploy');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});
+
+test('blank-ish first user content falls back to New chat title', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    db.db.prepare(`INSERT INTO sections (id, title, position) VALUES ('test', 'Test', 42)`).run();
+    db.db.prepare(`
+      INSERT INTO sessions (id, group_id, name, channel, preview, unread, chip, status, agent_id, agent_display_name)
+      VALUES ('fallback-chat', 'test', 'New chat', 'Slack', '', 0, 'dm', 'online', 'main', 'Main')
+    `).run();
+
+    db.addMessage({ sessionId: 'fallback-chat', role: 'user', content: '```code```' });
+    const session = db.getSessionById('fallback-chat');
+    assert.equal(session.name, 'New chat');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});
+
+test('agent metadata persists per chat and switch adds system timeline note', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    const alphaBefore = db.getSessionById('alpha');
+    const otherBefore = db.getSessionById('ops-alerts');
+
+    const result = db.setSessionAgent('alpha', { agentId: 'coder', agentDisplayName: 'Coder' });
+    assert.equal(result.session.agentId, 'coder');
+    assert.equal(result.session.agentDisplayName, 'Coder');
+    assert.equal(result.systemMessage.role, 'system');
+    assert.match(result.systemMessage.content, /Switched to Coder/);
+
+    const alphaAfter = db.getSessionById('alpha');
+    const otherAfter = db.getSessionById('ops-alerts');
+    assert.equal(alphaAfter.agentId, 'coder');
+    assert.equal(alphaAfter.agentDisplayName, 'Coder');
+    assert.equal(otherAfter.agentId, otherBefore.agentId);
+    assert.equal(otherAfter.agentDisplayName, otherBefore.agentDisplayName);
+    assert.equal(alphaBefore.id, alphaAfter.id);
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});
+
+test('gateway UUID session sync keeps compatibility with per-chat agents', (t) => {
+  const { db, tmpRoot, error } = createDb();
+  if (error) {
+    t.skip(`better-sqlite3 unavailable in node test runtime: ${error.message}`);
+    return;
+  }
+
+  try {
+    const uuid = '7f53f858-503f-4ca8-9f02-cf1f9b3c3a6a';
+    db.upsertGatewaySessions([{ sessionId: uuid, key: 'sess_1', kind: 'direct', model: 'gpt-5', updatedAt: Date.now() }]);
+
+    db.setSessionAgent(uuid, { agentId: 'planner', agentDisplayName: 'Planner' });
+    db.upsertGatewaySessions([{ sessionId: uuid, key: 'sess_1', kind: 'direct', model: 'gpt-5', updatedAt: Date.now() }]);
+
+    const session = db.getSessionById(uuid);
+    assert.equal(session.agentId, 'planner');
+    assert.equal(session.agentDisplayName, 'Planner');
+  } finally {
+    cleanupDb(db, tmpRoot);
+  }
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -88,6 +88,10 @@ ipcMain.handle('data:reset', () => {
   return database.resetData();
 });
 
+ipcMain.handle('data:set-session-agent', (_event, payload) => {
+  return database.setSessionAgent(payload?.sessionId, payload || {});
+});
+
 ipcMain.handle('data:sync-gateway-sessions', async () => {
   try {
     const { stdout } = await execFileAsync('openclaw', ['sessions', '--json'], { maxBuffer: 2 * 1024 * 1024 });
@@ -101,13 +105,14 @@ ipcMain.handle('data:sync-gateway-sessions', async () => {
 
 ipcMain.handle('data:send-message', async (_event, payload) => {
   const userMessage = database.addMessage(payload);
+  const session = database.getSessionById(payload?.sessionId);
 
   const looksLikeGatewaySession = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(payload?.sessionId || '');
 
   try {
     const args = looksLikeGatewaySession
       ? ['agent', '--session-id', payload.sessionId, '--message', payload.content, '--json']
-      : ['agent', '--agent', 'main', '--message', payload.content, '--json'];
+      : ['agent', '--agent', session?.agentId || 'main', '--message', payload.content, '--json'];
 
     const { stdout } = await execFileAsync(
       'openclaw',
@@ -123,7 +128,7 @@ ipcMain.handle('data:send-message', async (_event, payload) => {
       author: 'OpenClaw'
     });
 
-    return { userMessage, assistantMessage };
+    return { userMessage, assistantMessage, session: database.getSessionById(payload?.sessionId) };
   } catch (error) {
     const assistantMessage = database.addMessage({
       sessionId: payload.sessionId,
@@ -132,7 +137,7 @@ ipcMain.handle('data:send-message', async (_event, payload) => {
       author: 'System'
     });
 
-    return { userMessage, assistantMessage };
+    return { userMessage, assistantMessage, session: database.getSessionById(payload?.sessionId) };
   }
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('chatDesktop', {
     setComposerDrafts: (drafts) => ipcRenderer.invoke('data:set-composer-drafts', drafts),
     reset: () => ipcRenderer.invoke('data:reset'),
     syncGatewaySessions: () => ipcRenderer.invoke('data:sync-gateway-sessions'),
+    setSessionAgent: (payload) => ipcRenderer.invoke('data:set-session-agent', payload),
     sendMessage: (payload) => ipcRenderer.invoke('data:send-message', payload)
   }
 });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -569,7 +569,13 @@
     return seedData.sections.map((section) => ({
       id: section.id,
       title: section.title,
-      sessions: seedData.sessions.filter((session) => session.groupId === section.id)
+      sessions: seedData.sessions
+        .filter((session) => session.groupId === section.id)
+        .map((session) => ({
+          agentId: 'main',
+          agentDisplayName: 'Main',
+          ...session
+        }))
     }));
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -57,6 +57,12 @@
     degraded: { label: 'Degraded', tone: 'warning' }
   };
 
+  const agentOptions = [
+    { id: 'main', displayName: 'Main' },
+    { id: 'coder', displayName: 'Coder' },
+    { id: 'planner', displayName: 'Planner' }
+  ];
+
   let sections = buildSectionsFromSeed();
   let selectedSessionId = sections[0]?.sessions[0]?.id ?? null;
   let messages = buildMessagesFromSeed(selectedSessionId);
@@ -75,7 +81,10 @@
   let highlightTimeout;
   let draftPersistTimer;
   let showSettings = false;
-  let sideRailOpen = true;
+  let sideRailOpen = false;
+  let leftRailOpen = true;
+  let leftRailNav = 'chats';
+  let chatMenuOpenFor = null;
   let settingsSaving = false;
   let resettingData = false;
   let sendingMessage = false;
@@ -297,6 +306,8 @@
       return;
     }
 
+    chatMenuOpenFor = null;
+
     persistDraftForSession(selectedSessionId, composerValue);
     selectedSessionId = sessionId;
     selectedSession = findSession(sessionId);
@@ -315,14 +326,47 @@
     restoreDraftForSession(sessionId);
   }
 
-  function updateSessionPreview(sessionId, preview) {
+  function createNewChat() {
+    const sessionId = `local-${Date.now()}`;
+    const freshSession = {
+      id: sessionId,
+      name: 'New chat',
+      channel: 'Local',
+      preview: 'Start the conversation…',
+      unread: 0,
+      chip: 'local',
+      status: 'idle'
+    };
+
+    sections = sections.map((section, index) => {
+      if (index !== 0) return section;
+      return { ...section, sessions: [freshSession, ...section.sessions] };
+    });
+
+    void selectSession(sessionId);
+  }
+
+  function toggleChatMenu(event, sessionId) {
+    event.stopPropagation();
+    chatMenuOpenFor = chatMenuOpenFor === sessionId ? null : sessionId;
+  }
+
+  function handleChatMenuAction(event, sessionId) {
+    event.stopPropagation();
+    chatMenuOpenFor = null;
+    if (sessionId) {
+      errorMessage = `Chat actions are coming soon (${sessionId.slice(0, 8)}…).`;
+    }
+  }
+
+  function applySessionPatch(sessionId, patch = {}) {
     sections = sections.map((section) => {
       const hasSession = section.sessions.some((session) => session.id === sessionId);
       if (!hasSession) return section;
 
       const nextSessions = section.sessions.map((session) => (
         session.id === sessionId
-          ? { ...session, preview: preview.slice(0, 160) }
+          ? { ...session, ...patch }
           : session
       ));
 
@@ -356,7 +400,11 @@
       messages = incoming ? [...messages, outgoing, incoming] : [...messages, outgoing];
       composerValue = '';
       persistDraftForSession(selectedSessionId, '');
-      updateSessionPreview(selectedSessionId, incoming?.content || content);
+      if (delivery?.session) {
+        applySessionPatch(selectedSessionId, delivery.session);
+      } else {
+        applySessionPatch(selectedSessionId, { preview: (incoming?.content || content).slice(0, 160) });
+      }
       await tick();
       highlightMessage((incoming || outgoing)?.id);
     } catch (error) {
@@ -364,6 +412,33 @@
       errorMessage = 'Unable to send message right now.';
     } finally {
       sendingMessage = false;
+    }
+  }
+
+  async function handleAgentChange(event) {
+    const nextAgentId = event.currentTarget.value;
+    const nextAgent = agentOptions.find((item) => item.id === nextAgentId) ?? agentOptions[0];
+    if (!selectedSessionId || !nextAgent || selectedSession?.agentId === nextAgent.id) return;
+
+    try {
+      const client = dataClient ?? fallbackAdapter;
+      const result = await client.setSessionAgent({
+        sessionId: selectedSessionId,
+        agentId: nextAgent.id,
+        agentDisplayName: nextAgent.displayName
+      });
+
+      if (result?.session) {
+        applySessionPatch(selectedSessionId, result.session);
+      }
+      if (result?.systemMessage) {
+        messages = [...messages, result.systemMessage];
+        await tick();
+        highlightMessage(result.systemMessage.id);
+      }
+    } catch (error) {
+      console.error('Unable to switch agent', error);
+      errorMessage = 'Failed to switch agent for this chat.';
     }
   }
 
@@ -468,6 +543,12 @@
         return;
       }
 
+      if (event.key.toLowerCase() === 'b') {
+        event.preventDefault();
+        leftRailOpen = !leftRailOpen;
+        return;
+      }
+
       if (event.shiftKey && event.key === '[') {
         event.preventDefault();
         selectAdjacentSession(-1);
@@ -545,12 +626,46 @@
         timeZone: 'Europe/London'
       }).format(now);
 
+      const session = findSession(payload.sessionId);
+      const isFirstUserMessage = !messages.some((message) => message.role === 'user');
+
       return {
         id: `local-${now.getTime()}`,
         role: payload.role ?? 'user',
         author: payload.author ?? 'Operator',
         timestamp,
-        content: payload.content
+        content: payload.content,
+        session: {
+          ...session,
+          preview: payload.content.slice(0, 160),
+          name: isFirstUserMessage ? deriveChatTitle(payload.content) : session?.name
+        }
+      };
+    },
+    async setSessionAgent(payload) {
+      const now = new Date();
+      const session = findSession(payload.sessionId);
+      const timestamp = new Intl.DateTimeFormat('en-GB', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: 'Europe/London'
+      }).format(now);
+
+      return {
+        session: {
+          ...session,
+          agentId: payload.agentId,
+          agentDisplayName: payload.agentDisplayName
+        },
+        systemMessage: {
+          id: `local-switch-${now.getTime()}`,
+          role: 'system',
+          author: 'System',
+          timestamp,
+          content: `Switched to ${payload.agentDisplayName}`,
+          meta: { pill: 'switch', detail: payload.agentDisplayName }
+        }
       };
     },
     async searchMessages(query) {
@@ -573,6 +688,15 @@
         });
     }
   };
+
+  function deriveChatTitle(text) {
+    const cleaned = (text || '')
+      .replace(/[`*_#>\[\]()]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!cleaned) return 'New chat';
+    return cleaned.slice(0, 72);
+  }
 
   function escapeHtml(text) {
     return text.replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char] || char));
@@ -664,54 +788,79 @@
 </script>
 
 <div class="app-frame">
-  <header class="top-bar">
-    <div class="gateway">
-      <div>
-        <p class="eyebrow">Gateway</p>
-        <strong>{gateway.name}</strong>
-      </div>
-      <div class="gateway-meta">
-        <span class={`pill ${statusPills[gateway.status].tone}`}>{statusPills[gateway.status].label}</span>
-        <span class="meta">{gateway.endpoint}</span>
-        <span class="meta">Last heartbeat · {gateway.heartbeat}</span>
-      </div>
+  <header class="top-bar compact">
+    <div class="gateway-meta">
+      <span class={`pill ${statusPills[gateway.status].tone}`}>{statusPills[gateway.status].label}</span>
+      <span class="meta">{gateway.name}</span>
+      <span class="meta">{gateway.heartbeat}</span>
     </div>
     <div class="top-actions">
-      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
-      <button class="ghost" on:click={openLogsFolder}>Open logs</button>
-      <button class="primary" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
-        {syncInFlight ? 'Syncing…' : 'Sync chats'}
+      <button class="ghost" on:click={() => hydrateGatewaySessions()} disabled={syncInFlight}>
+        {syncInFlight ? 'Syncing…' : 'Sync'}
       </button>
+      <button class="ghost" on:click={() => (showSettings = true)}>Settings</button>
     </div>
   </header>
 
-  <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'}`}>
+  <div class={`shell-grid ${sideRailOpen ? '' : 'rail-collapsed'} ${leftRailOpen ? '' : 'left-collapsed'}`}>
     <aside class="session-rail" aria-label="Chat list">
-      {#each sections as section}
-        <div class="session-section">
-          <p class="section-label">{section.title}</p>
-          {#each section.sessions as session}
-            <button
-              class={`session-tile ${session.id === selectedSessionId ? 'active' : ''}`}
-              on:click={() => selectSession(session.id)}
-            >
-              <div class="tile-main">
-                <div>
-                  <div class="name-row">
-                    <span class="name">{session.name}</span>
-                    {#if session.unread}
-                      <span class="badge">{session.unread}</span>
-                    {/if}
+      <div class="rail-header">
+        <strong>OpenClaw Chat</strong>
+        <button class="ghost icon" on:click={() => (leftRailOpen = false)} title="Collapse sidebar">⟨</button>
+      </div>
+      <button class="primary new-chat" on:click={createNewChat}>+ New chat</button>
+      <nav class="rail-nav" aria-label="Primary navigation">
+        <button class={leftRailNav === 'chats' ? 'active' : ''} on:click={() => (leftRailNav = 'chats')}>Chats</button>
+        <button class={leftRailNav === 'agents' ? 'active' : ''} on:click={() => (leftRailNav = 'agents')}>Agents</button>
+      </nav>
+
+      {#if leftRailNav === 'chats'}
+        {#each sections as section}
+          <div class="session-section">
+            <p class="section-label">{section.title}</p>
+            {#each section.sessions as session}
+              <div
+                class={`session-tile ${session.id === selectedSessionId ? 'active' : ''}`}
+                role="button"
+                tabindex="0"
+                on:click={() => selectSession(session.id)}
+                on:keydown={(event) => event.key === 'Enter' && selectSession(session.id)}
+              >
+                <div class="tile-main">
+                  <div>
+                    <div class="name-row">
+                      <span class="name">{session.name}</span>
+                      <span class="agent-badge" title={`Active agent: ${session.agentDisplayName ?? 'Main'}`}>
+                        {session.agentDisplayName ?? 'Main'}
+                      </span>
+                      {#if session.unread}
+                        <span class="badge">{session.unread}</span>
+                      {/if}
+                    </div>
+                    <p class="preview">{session.channel} · {session.preview}</p>
                   </div>
-                  <p class="preview">{session.preview}</p>
                 </div>
-                <span class={`chip ${session.chip}`}>{session.channel}</span>
+                <div class="tile-actions">
+                  <button class="ghost icon" on:click={(event) => toggleChatMenu(event, session.id)} aria-label="Chat actions">⋯</button>
+                  {#if chatMenuOpenFor === session.id}
+                    <div class="chat-menu">
+                      <button on:click={(event) => handleChatMenuAction(event, session.id)}>Copy chat ID</button>
+                      <button on:click={(event) => handleChatMenuAction(event, session.id)}>Mute chat</button>
+                    </div>
+                  {/if}
+                </div>
               </div>
-              <span class={`status-dot ${session.status}`}></span>
-            </button>
-          {/each}
-        </div>
-      {/each}
+            {/each}
+          </div>
+        {/each}
+      {:else}
+        <div class="agents-placeholder meta">Agent management stays available here.</div>
+      {/if}
+
+      <footer class="rail-footer">
+        <button class="ghost" on:click={openLogsFolder}>Open logs</button>
+        <button class="ghost" on:click={() => (showSettings = true)}>Profile & settings</button>
+      </footer>
     </aside>
 
     <section class="timeline-area" aria-label="Conversation timeline">
@@ -719,8 +868,19 @@
         <div>
           <p class="eyebrow">Current chat</p>
           <h2>{selectedSession?.name ?? 'Chat'}</h2>
+          <label class="agent-switcher">
+            <span>Agent</span>
+            <select value={selectedSession?.agentId ?? 'main'} on:change={handleAgentChange}>
+              {#each agentOptions as agent}
+                <option value={agent.id}>{agent.displayName}</option>
+              {/each}
+            </select>
+          </label>
         </div>
         <div class="timeline-actions">
+          {#if !leftRailOpen}
+            <button class="ghost" on:click={() => (leftRailOpen = true)}>Show chats</button>
+          {/if}
           <input
             class="search-input"
             type="search"
@@ -730,9 +890,9 @@
             bind:this={searchInputEl}
             on:input={handleSearchInput}
           />
-          <button class="ghost" on:click={focusSearchInput}>Jump ⌘K</button>
+          <button class="ghost" on:click={focusSearchInput}>⌘K</button>
           <button class="ghost" on:click={() => (sideRailOpen = !sideRailOpen)}>
-            {sideRailOpen ? 'Hide panel' : 'Show panel'}
+            {sideRailOpen ? 'Hide details' : 'Show details'}
           </button>
         </div>
       </header>
@@ -773,7 +933,7 @@
       {#if loading}
         <div class="loading-state">Loading conversation…</div>
       {:else if !messages.length}
-        <div class="empty-state">No messages in this session yet.</div>
+        <div class="empty-state">No messages in this chat yet.</div>
       {:else}
         <div class="message-list">
           {#each messages as message}
@@ -822,6 +982,7 @@
         </div>
         <div class="composer-meta">
           <span class="meta">Send as · Operator</span>
+          <span class="meta">Agent · {selectedSession?.agentDisplayName ?? 'Main'}</span>
           <span class="meta">{composerGatewayStatus}</span>
         </div>
       </footer>

--- a/src/app.css
+++ b/src/app.css
@@ -348,6 +348,23 @@ button.icon {
   font-size: 1.4rem;
 }
 
+.agent-switcher {
+  margin-top: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  color: #a8b5db;
+}
+
+.agent-switcher select {
+  background: rgba(15, 18, 32, 0.9);
+  color: #dce6ff;
+  border: 1px solid rgba(157, 186, 252, 0.35);
+  border-radius: 8px;
+  padding: 0.2rem 0.45rem;
+}
+
 .timeline-actions {
   display: flex;
   gap: 0.5rem;

--- a/src/app.css
+++ b/src/app.css
@@ -120,14 +120,8 @@ body {
   backdrop-filter: blur(16px);
 }
 
-.gateway {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.gateway strong {
-  font-size: 1.1rem;
+.top-bar.compact {
+  padding: 0.6rem 1rem;
 }
 
 .gateway-meta {
@@ -181,27 +175,71 @@ button.primary:disabled {
 
 .shell-grid {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr) 360px;
+  grid-template-columns: 300px minmax(0, 1fr) 320px;
   flex: 1;
   overflow: hidden;
 }
 
 .shell-grid.rail-collapsed {
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: 300px minmax(0, 1fr);
+}
+
+.shell-grid.left-collapsed {
+  grid-template-columns: minmax(0, 1fr) 320px;
+}
+
+.shell-grid.left-collapsed.rail-collapsed {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .session-rail {
   border-right: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 1rem 1rem 1.5rem;
+  padding: 0.9rem;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.rail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+button.icon {
+  min-width: 32px;
+  padding: 0.35rem;
+}
+
+.new-chat {
+  width: 100%;
+}
+
+.rail-nav {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.4rem;
+}
+
+.rail-nav button {
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #b7c1e5;
+  padding: 0.45rem;
+}
+
+.rail-nav button.active {
+  background: rgba(122, 123, 255, 0.2);
+  color: #fff;
 }
 
 .session-section + .session-section {
-  margin-top: 1.25rem;
+  margin-top: 0.8rem;
 }
 
 .section-label {
-  margin: 0 0 0.3rem;
+  margin: 0 0 0.35rem;
   font-size: 0.75rem;
   color: #7c85a2;
   letter-spacing: 0.08em;
@@ -211,24 +249,18 @@ button.primary:disabled {
 .session-tile {
   width: 100%;
   background: rgba(255, 255, 255, 0.02);
-  border-radius: 14px;
-  padding: 0.75rem;
+  border-radius: 12px;
+  padding: 0.65rem;
   color: inherit;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.35rem;
+  position: relative;
 }
 
 .session-tile.active {
   background: linear-gradient(120deg, rgba(122, 123, 255, 0.18), rgba(167, 107, 255, 0.2));
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
-}
-
-.session-tile .tile-main {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
 }
 
 .name-row {
@@ -237,14 +269,21 @@ button.primary:disabled {
   gap: 0.4rem;
 }
 
-.name {
-  font-weight: 600;
+.name { font-weight: 600; }
+
+.agent-badge {
+  font-size: 0.64rem;
+  padding: 0.12rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(157, 186, 252, 0.18);
+  color: #cfe0ff;
 }
 
 .preview {
-  margin: 0.15rem 0 0;
-  font-size: 0.8rem;
+  margin: 0.1rem 0 0;
+  font-size: 0.76rem;
   color: #9ca7ce;
+  text-align: left;
 }
 
 .badge {
@@ -255,30 +294,37 @@ button.primary:disabled {
   font-size: 0.7rem;
 }
 
-.chip {
-  font-size: 0.65rem;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  background: rgba(255, 255, 255, 0.08);
-  color: #9dbafc;
+.tile-actions { position: relative; }
+
+.chat-menu {
+  position: absolute;
+  right: 0;
+  top: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  background: #141a2b;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  min-width: 130px;
+  z-index: 2;
 }
 
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #3d4a65;
+.chat-menu button {
+  background: transparent;
+  color: #d9e1ff;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
 }
 
-.status-dot.live {
-  background: #6dffb0;
-  box-shadow: 0 0 8px #6dffb0;
+.rail-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
-.status-dot.muted {
-  background: #484b5f;
+.agents-placeholder {
+  padding: 0.6rem;
 }
 
 .timeline-area {


### PR DESCRIPTION
## Summary\n- add per-chat active agent badge in chat list and header agent selector\n- wire agent switching to persist per chat and append subtle system switch notes to timeline\n- update composer metadata to show active chat agent\n- add regression tests for title generation/fallback, per-chat agent persistence, switch note emission, and UUID gateway session sync compatibility\n\n## Validation\n- 
> chat-desktop@0.0.0 test
> node --test electron/*.test.cjs

TAP version 13
# Subtest: extracts nested reply.message payload
ok 1 - extracts nested reply.message payload
  ---
  duration_ms: 2.242079
  type: 'test'
  ...
# Subtest: falls back through supported top-level keys
ok 2 - falls back through supported top-level keys
  ---
  duration_ms: 0.420211
  type: 'test'
  ...
# Subtest: extracts text from gateway result payloads
ok 3 - extracts text from gateway result payloads
  ---
  duration_ms: 0.301688
  type: 'test'
  ...
# Subtest: extracts text from object and block payloads
ok 4 - extracts text from object and block payloads
  ---
  duration_ms: 0.289375
  type: 'test'
  ...
# Subtest: extracts JSON payload when output contains log lines
ok 5 - extracts JSON payload when output contains log lines
  ---
  duration_ms: 1.036974
  type: 'test'
  ...
# Subtest: extracts JSON payload when wrapped in markdown code fences
ok 6 - extracts JSON payload when wrapped in markdown code fences
  ---
  duration_ms: 0.462432
  type: 'test'
  ...
# Subtest: extracts inline JSON object from prefixed log line
ok 7 - extracts inline JSON object from prefixed log line
  ---
  duration_ms: 2.082391
  type: 'test'
  ...
# Subtest: returns trimmed stdout when non-json
ok 8 - returns trimmed stdout when non-json
  ---
  duration_ms: 0.28845
  type: 'test'
  ...
# Subtest: returns empty string on empty input
ok 9 - returns empty string on empty input
  ---
  duration_ms: 0.577793
  type: 'test'
  ...
# Subtest: maps ENOENT to missing CLI message
ok 10 - maps ENOENT to missing CLI message
  ---
  duration_ms: 2.187916
  type: 'test'
  ...
# Subtest: prefers stderr details and includes timeout/exit context
ok 11 - prefers stderr details and includes timeout/exit context
  ---
  duration_ms: 0.298415
  type: 'test'
  ...
# Subtest: falls back to stdout or message when stderr missing
ok 12 - falls back to stdout or message when stderr missing
  ---
  duration_ms: 0.192337
  type: 'test'
  ...
# Subtest: uses fallback when no error details exist
ok 13 - uses fallback when no error details exist
  ---
  duration_ms: 0.212785
  type: 'test'
  ...
# Subtest: setComposerDrafts keeps non-empty drafts and drops blank entries
ok 14 - setComposerDrafts keeps non-empty drafts and drops blank entries # SKIP better-sqlite3 unavailable in node test runtime: The module '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'\\nwas compiled against a different Node.js version using\\nNODE_MODULE_VERSION 132. This version of Node.js requires\\nNODE_MODULE_VERSION 127. Please try re-compiling or re-installing\\nthe module (for instance, using `npm rebuild` or `npm install`).
  ---
  duration_ms: 4.941912
  type: 'test'
  ...
# Subtest: searchMessages tolerates punctuation-heavy queries
ok 15 - searchMessages tolerates punctuation-heavy queries # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 1.343486
  type: 'test'
  ...
# Subtest: searchMessages still returns matches for regular terms
ok 16 - searchMessages still returns matches for regular terms # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 1.549773
  type: 'test'
  ...
# Subtest: first user message generates chat title and later messages do not retitle
ok 17 - first user message generates chat title and later messages do not retitle # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 2.460197
  type: 'test'
  ...
# Subtest: blank-ish first user content falls back to New chat title
ok 18 - blank-ish first user content falls back to New chat title # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 1.245996
  type: 'test'
  ...
# Subtest: agent metadata persists per chat and switch adds system timeline note
ok 19 - agent metadata persists per chat and switch adds system timeline note # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 0.94801
  type: 'test'
  ...
# Subtest: gateway UUID session sync keeps compatibility with per-chat agents
ok 20 - gateway UUID session sync keeps compatibility with per-chat agents # SKIP better-sqlite3 unavailable in node test runtime: Module did not self-register: '/home/richard/.openclaw/workspace/openclaw-local-chat/node_modules/better-sqlite3/build/Release/better_sqlite3.node'.
  ---
  duration_ms: 0.938596
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles direct array payload
ok 21 - normalizeGatewaySessionsPayload handles direct array payload
  ---
  duration_ms: 2.219297
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles { sessions } object payload
ok 22 - normalizeGatewaySessionsPayload handles { sessions } object payload
  ---
  duration_ms: 0.334402
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles { data } object payload
ok 23 - normalizeGatewaySessionsPayload handles { data } object payload
  ---
  duration_ms: 0.220079
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles nested sessions.items payload
ok 24 - normalizeGatewaySessionsPayload handles nested sessions.items payload
  ---
  duration_ms: 1.543302
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles nested result payload
ok 25 - normalizeGatewaySessionsPayload handles nested result payload
  ---
  duration_ms: 0.352835
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload handles nested payload/data/items wrappers
ok 26 - normalizeGatewaySessionsPayload handles nested payload/data/items wrappers
  ---
  duration_ms: 0.235458
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload safely handles cyclic objects
ok 27 - normalizeGatewaySessionsPayload safely handles cyclic objects
  ---
  duration_ms: 0.73414
  type: 'test'
  ...
# Subtest: normalizeGatewaySessionsPayload returns empty array for unknown payloads
ok 28 - normalizeGatewaySessionsPayload returns empty array for unknown payloads
  ---
  duration_ms: 0.352025
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput handles raw json payload
ok 29 - parseGatewaySessionsOutput handles raw json payload
  ---
  duration_ms: 0.772621
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput extracts inline json from log output
ok 30 - parseGatewaySessionsOutput extracts inline json from log output
  ---
  duration_ms: 1.460148
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput extracts fenced json payload
ok 31 - parseGatewaySessionsOutput extracts fenced json payload
  ---
  duration_ms: 0.624899
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput extracts data: prefixed json line
ok 32 - parseGatewaySessionsOutput extracts data: prefixed json line
  ---
  duration_ms: 0.382648
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput extracts inline JSON array from log output
ok 33 - parseGatewaySessionsOutput extracts inline JSON array from log output
  ---
  duration_ms: 0.264666
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput extracts data: prefixed JSON array line
ok 34 - parseGatewaySessionsOutput extracts data: prefixed JSON array line
  ---
  duration_ms: 0.278024
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput prefers latest fenced json payload
ok 35 - parseGatewaySessionsOutput prefers latest fenced json payload
  ---
  duration_ms: 0.274438
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput unwraps json-encoded string payload
ok 36 - parseGatewaySessionsOutput unwraps json-encoded string payload
  ---
  duration_ms: 0.221679
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput unwraps data: prefixed json-encoded array payload
ok 37 - parseGatewaySessionsOutput unwraps data: prefixed json-encoded array payload
  ---
  duration_ms: 0.353234
  type: 'test'
  ...
# Subtest: parseGatewaySessionsOutput returns empty array for invalid output
ok 38 - parseGatewaySessionsOutput returns empty array for invalid output
  ---
  duration_ms: 0.262383
  type: 'test'
  ...
1..38
# tests 38
# suites 0
# pass 31
# fail 0
# cancelled 0
# skipped 7
# todo 0
# duration_ms 250.464254\n- 
> chat-desktop@0.0.0 build
> vite build && npm run build:electron

vite v7.3.1 building client environment for production...
transforming...
✓ 109 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  0.46 kB │ gzip:  0.29 kB
dist/assets/index-BCqpgZbP.css   9.40 kB │ gzip:  2.67 kB
dist/assets/index-DYRFSODW.js   62.11 kB │ gzip: 23.41 kB
✓ built in 1.32s

> chat-desktop@0.0.0 build:electron
> cross-env NODE_ENV=production electron-builder --config electron-builder.yml

  • electron-builder  version=25.1.8 os=6.17.1-300.fc43.x86_64
  • loaded configuration  file=/home/richard/.openclaw/workspace/openclaw-local-chat/electron-builder.yml
  • executing @electron/rebuild  electronVersion=34.5.8 arch=x64 buildFromSource=false appDir=./
  • installing native dependencies  arch=x64
  • preparing       moduleName=better-sqlite3 arch=x64
  • finished        moduleName=better-sqlite3 arch=x64
  • completed installing native dependencies
  • packaging       platform=linux arch=x64 electron=34.5.8 appOutDir=release/linux-unpacked
  • building        target=AppImage arch=x64 file=release/OpenClaw Chat Desktop-0.0.0.AppImage
  • default Electron icon is used  reason=application icon is not set\n\nCloses #11\nCloses #13